### PR TITLE
Add Coding convention, pre-commit-hooks, as well as a first Contributing Guide

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+exclude = .git,docs
+per-file-ignores = __init__.py: F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.2.3
+    hooks:
+    - id: nbqa-black
+    - id: nbqa-isort
+    - id: nbqa-flake8
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing Guide
+
+Thank you for your interest in contributing to Hydrogym! There are many ways to contribute, and appreciate any and all contributions. In case you have questions please do not hesitate to open an [issue](https://github.com/dynamicslab/hydrogym/issues) to open up a discussion.
+
+## Getting started
+
+1. Fork the library on GitHub.
+2. Clone and install the library in development mode
+
+    ```bash
+    git clone https://github.com/your-username-to-go-here/hydrogym.git
+    cd hydrogym
+    pip install -e .
+    ```
+
+3. Install the pre-commit hooks
+
+    ```bash
+    pip install pre-commit
+    pre-commit install
+    ```
+
+which will use [Black](https://black.readthedocs.io/en/stable/) and [isort](https://github.com/PyCQA/isort) to format the code before linting it with [flake8](https://flake8.pycqa.org/en/latest/).
+
+## Making changes to the code
+
+If possible, please try to add isolated tests for your changes where possible, and add comments regarding the verification of results against the respective results in literature. You can then subseqently add a pull-request against the main repository to add your changes.
+
+## Code of Conduct
+
+We expect all participants to abide by the [Python Community Code of Conduct](https://www.python.org/psf/conduct/).


### PR DESCRIPTION
Additions in this PR:

- flake8 style-file
- pre-commit hooks using black, isort, and flake8-linting
- an initial contributing guide, which contains a code of conduct reference to the Python Community Code of Conduct

Addresses all points raised in issue #39 