### PR TITLE
Python Dependency Upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ evotorch = "^0.3.0"
 gmsh = "^4.11.1"
 gym = "^0.26.2"
 modred = "^2.1.0"
-python = "^3.8"
-torch = "1.13"
+python = "^3.10"
+torch = "^2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 jupyterlab = "^3.5.2"


### PR DESCRIPTION
Bumping python package versions:

Python: >3.8 became >3.10
PyTorch: >1.13 became >2.0.0