### PR TITLE
Pre-allocate function to store vorticity

### DIFF
--- a/examples/cylinder/pressure-probes.py
+++ b/examples/cylinder/pressure-probes.py
@@ -30,7 +30,7 @@ flow = hgym.Cylinder(
     Re=100,
     mesh=mesh,
     velocity_order=velocity_order,
-    observation_type="pressure_probes",
+    observation_type="vorticity_probes",
     probes=probes,
 )
 

--- a/hydrogym/firedrake/flow.py
+++ b/hydrogym/firedrake/flow.py
@@ -151,6 +151,8 @@ class FlowConfig(PDEBase):
 
     self.split_solution()  # Break out and rename main solution
 
+    self._vorticity = fd.Function(self.pressure_space, name="vort")
+
   def set_state(self, q: fd.Function):
     """Set the current state fields
 
@@ -207,9 +209,8 @@ class FlowConfig(PDEBase):
         """
     if u is None:
       u = self.u
-    vort = fd.project(curl(u), self.pressure_space)
-    vort.rename("vort")
-    return vort
+    self._vorticity.interpolate(curl(u))
+    return self._vorticity
 
   def function_spaces(self, mixed: bool = True):
     """Function spaces for velocity and pressure

--- a/hydrogym/firedrake/flow.py
+++ b/hydrogym/firedrake/flow.py
@@ -209,7 +209,7 @@ class FlowConfig(PDEBase):
         """
     if u is None:
       u = self.u
-    self._vorticity.interpolate(curl(u))
+    self._vorticity.project(curl(u))
     return self._vorticity
 
   def function_spaces(self, mixed: bool = True):


### PR DESCRIPTION
Following conversation with @cl126162, the performance of the "vorticity probes" is much worse than pressure or velocity.  Seems like the reason is the construction of a new `fd.Function` every time `flow.vorticity()` is called, which allocates a lot of memory.  This PR just preallocates a field to hold the vorticity - after this the performance of vorticity probing is about the same as pressure.