### PR TITLE
Add Algolia DocSearch integration to docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -150,6 +150,13 @@ const config: Config = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} HydroGym Project.`,
     },
+    algolia: {
+      appId: 'KLP3S9F9ZZ',
+      apiKey: 'f1924b74902281f67c30b820e76a0ead',
+      indexName: 'HydroGym',
+      contextualSearch: true,
+      searchPagePath: 'search',
+    },
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,


### PR DESCRIPTION
Wire up the Algolia search bar via themeConfig.algolia now that the index has been crawled. Enables contextual search and a dedicated /search page out of the box via the preset-classic bundled theme.