### PR TITLE
Audit Phase 2: kwargs/config fixes (Tasks 2.1-2.15)

### DIFF
--- a/hydrogym/core.py
+++ b/hydrogym/core.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 from typing import Any, Callable, Iterable, Tuple, TypeVar, Union
 
 import gymnasium as gym
@@ -45,13 +46,17 @@ class PDEBase(metaclass=abc.ABCMeta):
     BCType = TypeVar("BCType")
 
     def __init__(self, **config):
-        self.mesh = self.load_mesh(name=config.get("mesh", self.DEFAULT_MESH))
+        # Consume the keys PDEBase itself owns. Subclasses consume their own
+        # keys (with .pop) before calling super().__init__; anything left in
+        # `config` after that is almost certainly a typo'd or unsupported
+        # option, so warn rather than silently ignoring it (audit Task 2.1).
+        self.mesh = self.load_mesh(name=config.pop("mesh", self.DEFAULT_MESH))
         self.initialize_state()
 
         self.reset()
 
         # Handle both single checkpoint (string) and multiple checkpoints (list)
-        restart = config.get("restart")
+        restart = config.pop("restart", None)
         if restart is not None:
             if isinstance(restart, str):
                 # Single checkpoint - load immediately
@@ -63,6 +68,14 @@ class PDEBase(metaclass=abc.ABCMeta):
                     self.load_checkpoint(restart[0])
             else:
                 raise ValueError(f"restart must be a string or list of strings, got {type(restart)}")
+
+        leftover = sorted(config)
+        if leftover:
+            warnings.warn(
+                f"{type(self).__name__} got unsupported flow_config key(s) {leftover}; "
+                "they have no effect and may indicate a misspelled option.",
+                stacklevel=2,
+            )
 
     @property
     @abc.abstractmethod

--- a/hydrogym/data_manager.py
+++ b/hydrogym/data_manager.py
@@ -253,6 +253,8 @@ class HFDataManager:
         local_fallback_dir: Optional[str] = None,
         use_clean_cache: Union[bool, str] = True,
         fallback_profile: str = "MAIA_LB",
+        token: Optional[str] = None,
+        revision: Optional[str] = None,
     ):
         """
         Initialize the HF Data Manager.
@@ -275,8 +277,16 @@ class HFDataManager:
                 Defaults to ``'MAIA_LB'``.  Pass the environment class's
                 ``SOLVER_TYPE`` attribute to get the right fallback in offline /
                 legacy scenarios.
+            token: Hugging Face access token, for private/gated repos. ``None``
+                (default) preserves ambient authentication (``HF_TOKEN`` env var
+                or ``huggingface-cli login``).
+            revision: Git revision (branch name, tag, or commit hash) to pin
+                downloads and file listings to. ``None`` (default) uses the
+                repo's default branch.
         """
         self.repo_id = repo_id
+        self.token = token
+        self.revision = revision
         self.cache_dir = cache_dir or os.path.expanduser("~/.cache/hydrogym")
         # cache_dir as the user actually passed it (None when defaulted). Only
         # an explicitly-set cache_dir is forwarded to snapshot_download(); see
@@ -340,8 +350,8 @@ class HFDataManager:
         # 3. Query HF file listing (no download, requires network)
         if HF_AVAILABLE:
             try:
-                api = HfApi()
-                repo_files = api.list_repo_files(self.repo_id, repo_type="dataset")
+                api = HfApi(token=self.token)
+                repo_files = api.list_repo_files(self.repo_id, repo_type="dataset", revision=self.revision)
                 for file_path in repo_files:
                     parts = file_path.split("/")
                     if len(parts) == 2 and parts[0] == env_name and parts[1] in _SENTINEL_TO_PROFILE:
@@ -368,8 +378,8 @@ class HFDataManager:
         """
         if HF_AVAILABLE:
             try:
-                api = HfApi()
-                repo_files = api.list_repo_files(self.repo_id, repo_type="dataset")
+                api = HfApi(token=self.token)
+                repo_files = api.list_repo_files(self.repo_id, repo_type="dataset", revision=self.revision)
 
                 env_names = set()
                 for file_path in repo_files:
@@ -537,6 +547,8 @@ class HFDataManager:
                     allow_patterns=f"{env_name}/**",
                     force_download=force_download,
                     cache_dir=self._hf_download_cache_dir,
+                    token=self.token,
+                    revision=self.revision,
                 )
                 hf_env_path = os.path.join(hf_cache_path, env_name)
                 if os.path.exists(hf_env_path) and os.path.isdir(hf_env_path):
@@ -601,6 +613,8 @@ class HFDataManager:
                     allow_patterns=f"{env_name}/**",
                     force_download=force_download,
                     cache_dir=self._hf_download_cache_dir,
+                    token=self.token,
+                    revision=self.revision,
                 )
                 hf_env_path = os.path.join(hf_cache_path, env_name)
                 if os.path.exists(hf_env_path) and os.path.isdir(hf_env_path):
@@ -641,6 +655,8 @@ class HFDataManager:
                     allow_patterns=f"{env_name}/**",
                     force_download=force_download,
                     cache_dir=self._hf_download_cache_dir,
+                    token=self.token,
+                    revision=self.revision,
                 )
                 env_path = os.path.join(hf_cache_path, env_name)
                 if os.path.exists(env_path) and self._validate_environment_files(env_path, profile):

--- a/hydrogym/data_manager.py
+++ b/hydrogym/data_manager.py
@@ -261,6 +261,9 @@ class HFDataManager:
             repo_id: Hugging Face repository ID.
             cache_dir: Clean local cache directory (default: ``~/.cache/hydrogym``).
                 Only used for HF downloads; local_fallback_dir is used directly.
+                When explicitly set, it is also passed to ``snapshot_download`` so
+                the raw HF download cache lands under it instead of the
+                huggingface_hub default (~/.cache/huggingface).
             local_fallback_dir: Local directory with environment files used when HF
                 is unreachable. When available, used directly without cache layer.
             use_clean_cache:
@@ -275,6 +278,11 @@ class HFDataManager:
         """
         self.repo_id = repo_id
         self.cache_dir = cache_dir or os.path.expanduser("~/.cache/hydrogym")
+        # cache_dir as the user actually passed it (None when defaulted). Only
+        # an explicitly-set cache_dir is forwarded to snapshot_download(); see
+        # the download helpers. ``cache_dir`` itself is never None so the clean
+        # cache layer keeps working unchanged.
+        self._hf_download_cache_dir = cache_dir
         self.local_fallback_dir = local_fallback_dir
         self.use_clean_cache = use_clean_cache
         self.fallback_profile = fallback_profile
@@ -528,6 +536,7 @@ class HFDataManager:
                     repo_type="dataset",
                     allow_patterns=f"{env_name}/**",
                     force_download=force_download,
+                    cache_dir=self._hf_download_cache_dir,
                 )
                 hf_env_path = os.path.join(hf_cache_path, env_name)
                 if os.path.exists(hf_env_path) and os.path.isdir(hf_env_path):
@@ -591,6 +600,7 @@ class HFDataManager:
                     repo_type="dataset",
                     allow_patterns=f"{env_name}/**",
                     force_download=force_download,
+                    cache_dir=self._hf_download_cache_dir,
                 )
                 hf_env_path = os.path.join(hf_cache_path, env_name)
                 if os.path.exists(hf_env_path) and os.path.isdir(hf_env_path):
@@ -630,6 +640,7 @@ class HFDataManager:
                     repo_type="dataset",
                     allow_patterns=f"{env_name}/**",
                     force_download=force_download,
+                    cache_dir=self._hf_download_cache_dir,
                 )
                 env_path = os.path.join(hf_cache_path, env_name)
                 if os.path.exists(env_path) and self._validate_environment_files(env_path, profile):

--- a/hydrogym/firedrake/flow.py
+++ b/hydrogym/firedrake/flow.py
@@ -89,6 +89,8 @@ class FlowConfig(PDEBase):
         cache_dir = config.pop("cache_dir", None)  # Custom cache directory (optional)
         local_dir = config.pop("local_dir", None)  # Local fallback directory (optional)
         use_HF_data_manager = config.pop("use_HF_data_manager", True)  # Control HF data manager usage (default: True)
+        hf_token = config.pop("hf_token", None)  # HF access token, private/gated repos (optional)
+        hf_revision = config.pop("hf_revision", None)  # HF revision to pin downloads to (optional)
 
         # Extract numeric Reynolds number from Firedrake Constant
         Re_value = int(float(self.Re))
@@ -100,6 +102,8 @@ class FlowConfig(PDEBase):
             cache_dir=cache_dir,
             local_dir=local_dir,
             use_HF_data_manager=use_HF_data_manager,
+            hf_token=hf_token,
+            hf_revision=hf_revision,
         )
 
         # Store resolved checkpoint path for verification/debugging
@@ -109,7 +113,9 @@ class FlowConfig(PDEBase):
 
         super().__init__(**config)
 
-    def _resolve_checkpoint(self, restart, Re, mesh, cache_dir=None, local_dir=None, use_HF_data_manager=True):
+    def _resolve_checkpoint(
+        self, restart, Re, mesh, cache_dir=None, local_dir=None, use_HF_data_manager=True, hf_token=None, hf_revision=None
+    ):
         """Resolve checkpoint parameter to actual file path(s).
 
             Handles four cases:
@@ -125,6 +131,8 @@ class FlowConfig(PDEBase):
             cache_dir: Custom cache directory (optional)
             local_dir: Local fallback directory (optional)
             use_HF_data_manager: Whether to use HF data manager for checkpoint resolution (default: True)
+            hf_token: HF access token, for private/gated repos (optional)
+            hf_revision: HF revision to pin downloads to (optional)
 
         Returns:
             None, str (resolved path), or list of str (resolved paths)
@@ -137,7 +145,13 @@ class FlowConfig(PDEBase):
             logging.log(logging.INFO, f"No checkpoint specified, attempting to auto-load: {env_name}")
 
             resolved = self._resolve_single_checkpoint(
-                env_name, cache_dir, local_dir, use_HF_data_manager=use_HF_data_manager, silent=True
+                env_name,
+                cache_dir,
+                local_dir,
+                use_HF_data_manager=use_HF_data_manager,
+                hf_token=hf_token,
+                hf_revision=hf_revision,
+                silent=True,
             )
             if resolved is None:
                 logging.log(logging.INFO, f"No checkpoint found for {env_name}, starting from zeros")
@@ -145,7 +159,12 @@ class FlowConfig(PDEBase):
 
         if isinstance(restart, str):
             return self._resolve_single_checkpoint(
-                restart, cache_dir, local_dir, use_HF_data_manager=use_HF_data_manager
+                restart,
+                cache_dir,
+                local_dir,
+                use_HF_data_manager=use_HF_data_manager,
+                hf_token=hf_token,
+                hf_revision=hf_revision,
             )
 
         elif isinstance(restart, (list, tuple)):
@@ -153,7 +172,12 @@ class FlowConfig(PDEBase):
             resolved = []
             for ckpt in restart:
                 resolved_ckpt = self._resolve_single_checkpoint(
-                    ckpt, cache_dir, local_dir, use_HF_data_manager=use_HF_data_manager
+                    ckpt,
+                    cache_dir,
+                    local_dir,
+                    use_HF_data_manager=use_HF_data_manager,
+                    hf_token=hf_token,
+                    hf_revision=hf_revision,
                 )
                 if resolved_ckpt is not None:
                     resolved.append(resolved_ckpt)
@@ -164,7 +188,7 @@ class FlowConfig(PDEBase):
             return None
 
     def _resolve_single_checkpoint(
-        self, checkpoint, cache_dir=None, local_dir=None, use_HF_data_manager=True, silent=False
+        self, checkpoint, cache_dir=None, local_dir=None, use_HF_data_manager=True, hf_token=None, hf_revision=None, silent=False
     ):
         """Resolve a single checkpoint path or environment name.
 
@@ -215,6 +239,8 @@ class FlowConfig(PDEBase):
                 local_fallback_dir=local_dir,  # Use local directory for offline/testing
                 use_clean_cache="copy",  # Use 'copy' for readable ckpts
                 fallback_profile="FIREDRAKE",
+                token=hf_token,  # Optional HF access token (private/gated repos)
+                revision=hf_revision,  # Optional revision to pin downloads to
             )
 
             # Get environment path (downloads if needed)

--- a/hydrogym/firedrake/flow.py
+++ b/hydrogym/firedrake/flow.py
@@ -85,7 +85,12 @@ class FlowConfig(PDEBase):
 
         # Process restart parameter - resolve environment names to checkpoint paths
         # or auto-infer from flow configuration
-        mesh = config.get("mesh", self.MESH_DIR)
+        # NOTE: the fallback must be the mesh NAME (DEFAULT_MESH, e.g. "medium"),
+        # not MESH_DIR (a filesystem path) -- the value is interpolated into the
+        # auto-inferred HF checkpoint env name below, so the old MESH_DIR
+        # fallback produced names like "..._FD" with a slash-containing path
+        # that could never match an environment on the Hub.
+        mesh = config.get("mesh", self.DEFAULT_MESH)
         cache_dir = config.pop("cache_dir", None)  # Custom cache directory (optional)
         local_dir = config.pop("local_dir", None)  # Local fallback directory (optional)
         use_HF_data_manager = config.pop("use_HF_data_manager", True)  # Control HF data manager usage (default: True)

--- a/hydrogym/firedrake/flow.py
+++ b/hydrogym/firedrake/flow.py
@@ -119,7 +119,15 @@ class FlowConfig(PDEBase):
         super().__init__(**config)
 
     def _resolve_checkpoint(
-        self, restart, Re, mesh, cache_dir=None, local_dir=None, use_HF_data_manager=True, hf_token=None, hf_revision=None
+        self,
+        restart,
+        Re,
+        mesh,
+        cache_dir=None,
+        local_dir=None,
+        use_HF_data_manager=True,
+        hf_token=None,
+        hf_revision=None,
     ):
         """Resolve checkpoint parameter to actual file path(s).
 
@@ -193,7 +201,14 @@ class FlowConfig(PDEBase):
             return None
 
     def _resolve_single_checkpoint(
-        self, checkpoint, cache_dir=None, local_dir=None, use_HF_data_manager=True, hf_token=None, hf_revision=None, silent=False
+        self,
+        checkpoint,
+        cache_dir=None,
+        local_dir=None,
+        use_HF_data_manager=True,
+        hf_token=None,
+        hf_revision=None,
+        silent=False,
     ):
         """Resolve a single checkpoint path or environment name.
 

--- a/hydrogym/firedrake/flow.py
+++ b/hydrogym/firedrake/flow.py
@@ -58,7 +58,7 @@ class FlowConfig(PDEBase):
     FUNCTIONS = ("q",)  # tuple of functions necessary for the flow
 
     def __init__(self, velocity_order=None, **config):
-        self.Re = fd.Constant(ufl.real(config.get("Re", self.DEFAULT_REYNOLDS)))
+        self.Re = fd.Constant(ufl.real(config.pop("Re", self.DEFAULT_REYNOLDS)))
 
         if velocity_order is None:
             velocity_order = self.DEFAULT_VELOCITY_ORDER
@@ -90,7 +90,7 @@ class FlowConfig(PDEBase):
         # auto-inferred HF checkpoint env name below, so the old MESH_DIR
         # fallback produced names like "..._FD" with a slash-containing path
         # that could never match an environment on the Hub.
-        mesh = config.get("mesh", self.DEFAULT_MESH)
+        mesh = config.pop("mesh", self.DEFAULT_MESH)
         cache_dir = config.pop("cache_dir", None)  # Custom cache directory (optional)
         local_dir = config.pop("local_dir", None)  # Local fallback directory (optional)
         use_HF_data_manager = config.pop("use_HF_data_manager", True)  # Control HF data manager usage (default: True)
@@ -101,7 +101,7 @@ class FlowConfig(PDEBase):
         Re_value = int(float(self.Re))
 
         resolved_restart = self._resolve_checkpoint(
-            restart=config.get("restart"),
+            restart=config.pop("restart", None),
             Re=Re_value,
             mesh=mesh,
             cache_dir=cache_dir,

--- a/hydrogym/firedrake/solvers/base.py
+++ b/hydrogym/firedrake/solvers/base.py
@@ -1,12 +1,10 @@
 import firedrake as fd
-import numpy as np
 from firedrake import logging
 from ufl import as_ufl, div, dot, ds, dx, inner, lhs, nabla_grad, rhs
 
 from hydrogym.core import TransientSolver
 from hydrogym.firedrake import FlowConfig
 from hydrogym.firedrake.solvers.stabilization import ns_stabilization
-from hydrogym.firedrake.utils import white_noise
 
 __all__ = ["NewtonSolver"]
 
@@ -73,15 +71,12 @@ class NewtonSolver:
 
 
 class NavierStokesTransientSolver(TransientSolver):
-    def __init__(
-        self,
-        flow: FlowConfig,
-        dt: float = None,
-        eta: float = 0.0,
-        debug: bool = False,
-        max_noise_iter: int = int(1e8),
-        noise_cutoff: float = None,
-    ):
+    def __init__(self, flow: FlowConfig, dt: float = None, debug: bool = False):
+        # NOTE: this class previously accepted eta/max_noise_iter/noise_cutoff
+        # for a random white-noise body forcing, but the forcing itself was
+        # removed upstream in a067781 ("Clean up old forcing code", 2024-03)
+        # and the kwargs were silently ignored ever since -- they were removed
+        # in this repo's audit Task 2.3 for exactly that reason.
         super().__init__(flow, dt)
         self.debug = debug
         self.reset()

--- a/hydrogym/firedrake/solvers/integrate.py
+++ b/hydrogym/firedrake/solvers/integrate.py
@@ -28,6 +28,4 @@ def integrate(
         raise ValueError(f"`method` must be one of {METHODS.keys()}")
 
     solver = METHODS[method](flow, dt, **options)
-    return solver.solve(
-        t_span, callbacks=callbacks, controller=controller, collect_rewards=collect_rewards
-    )
+    return solver.solve(t_span, callbacks=callbacks, controller=controller, collect_rewards=collect_rewards)

--- a/hydrogym/firedrake/solvers/integrate.py
+++ b/hydrogym/firedrake/solvers/integrate.py
@@ -8,9 +8,26 @@ METHODS = {
 }
 
 
-def integrate(flow, t_span, dt, method="BDF", callbacks=[], controller=None, **options):
+def integrate(
+    flow,
+    t_span,
+    dt,
+    method="BDF",
+    callbacks=[],
+    controller=None,
+    collect_rewards=False,
+    **options,
+):
+    """Integrate the flow forward in time with the chosen transient method.
+
+    All transient methods share `core.TransientSolver.solve`, which supports
+    optional reward collection: pass `collect_rewards=True` to get back a
+    `(flow, rewards)` tuple instead of just the final flow state.
+    """
     if method not in METHODS:
         raise ValueError(f"`method` must be one of {METHODS.keys()}")
 
     solver = METHODS[method](flow, dt, **options)
-    return solver.solve(t_span, callbacks=callbacks, controller=controller)
+    return solver.solve(
+        t_span, callbacks=callbacks, controller=controller, collect_rewards=collect_rewards
+    )

--- a/hydrogym/jax/env_core.py
+++ b/hydrogym/jax/env_core.py
@@ -61,6 +61,36 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
     # (offline / legacy data). Must be a key of data_manager.SOLVER_PROFILES.
     SOLVER_TYPE: str = "JAX"
 
+    @staticmethod
+    def _resolve_num_substeps(cfg_section) -> int:
+        """
+        Resolve the per-actuation substep count from the environment's YAML
+        config section (e.g. cfg.jax).
+
+        ``num_substeps`` is the primary key (matching Firedrake's
+        non-deprecated name and core.py's actuation_config); the old
+        ``num_sim_substeps_per_actuation`` key keeps working with a
+        DeprecationWarning.
+
+        Raises:
+            ConfigError: If the section defines neither key.
+        """
+        import warnings
+
+        if "num_substeps" in cfg_section:
+            return cfg_section["num_substeps"]
+        if "num_sim_substeps_per_actuation" in cfg_section:
+            warnings.warn(
+                "num_sim_substeps_per_actuation in the environment config is deprecated, rename it to num_substeps",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return cfg_section["num_sim_substeps_per_actuation"]
+        raise ConfigError(
+            "Environment config section defines neither 'num_substeps' nor (deprecated) "
+            "'num_sim_substeps_per_actuation'"
+        )
+
     def __init__(self, env_config: Dict):
         """
         Initialize the JAXFlowEnv environment.
@@ -122,7 +152,7 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
 
         self.runtime_property_file = os.path.join(self.env_data_path, "properties_run.toml")
 
-        self.num_substeps_per_iteration = self.cfg.jax.num_sim_substeps_per_actuation
+        self.num_substeps_per_iteration = self._resolve_num_substeps(self.cfg.jax)
         self.observation_type = self.cfg.jax.observation_type
         self.max_episode_steps = self.cfg.env.max_episode_steps
         self.num_inputs = self.cfg.jax.num_action_inputs * self.cfg.env.n_agents

--- a/hydrogym/jax/env_core.py
+++ b/hydrogym/jax/env_core.py
@@ -57,6 +57,10 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
         action_space: Gymnax action space.
     """
 
+    # Solver profile used by HFDataManager when no sentinel file is found
+    # (offline / legacy data). Must be a key of data_manager.SOLVER_PROFILES.
+    SOLVER_TYPE: str = "JAX"
+
     def __init__(self, env_config: Dict):
         """
         Initialize the JAXFlowEnv environment.
@@ -84,7 +88,10 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
         self.use_clean_cache = env_config.get("use_clean_cache", True)
 
         self.data_manager = HFDataManager(
-            repo_id=self.hf_repo_id, local_fallback_dir=self.local_fallback_dir, use_clean_cache=self.use_clean_cache
+            repo_id=self.hf_repo_id,
+            local_fallback_dir=self.local_fallback_dir,
+            use_clean_cache=self.use_clean_cache,
+            fallback_profile=self.SOLVER_TYPE,
         )
 
         # Environment identification

--- a/hydrogym/jax/env_core.py
+++ b/hydrogym/jax/env_core.py
@@ -116,12 +116,16 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
         self.hf_repo_id = env_config.get("hf_repo_id", "dynamicslab/HydroGym-environments")
         self.local_fallback_dir = env_config.get("local_fallback_dir", None)
         self.use_clean_cache = env_config.get("use_clean_cache", True)
+        self.hf_token = env_config.get("hf_token", None)
+        self.hf_revision = env_config.get("hf_revision", None)
 
         self.data_manager = HFDataManager(
             repo_id=self.hf_repo_id,
             local_fallback_dir=self.local_fallback_dir,
             use_clean_cache=self.use_clean_cache,
             fallback_profile=self.SOLVER_TYPE,
+            token=self.hf_token,
+            revision=self.hf_revision,
         )
 
         # Environment identification

--- a/hydrogym/jax/env_core.py
+++ b/hydrogym/jax/env_core.py
@@ -145,7 +145,7 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
         """
         Download and setup environment data from HF Hub.
 
-        First checks ~/.cache/maiagym/ for local data, otherwise falls back to data_manager.
+        First checks ~/.cache/jaxgym/ for local data, otherwise falls back to data_manager.
 
         Returns:
             Path to the local environment data directory.
@@ -154,7 +154,7 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
             ConfigError: If environment data cannot be retrieved.
         """
         # Check cache directory first
-        cache_dir = Path.home() / ".cache" / "maiagym" / self.environment_name
+        cache_dir = Path.home() / ".cache" / "jaxgym" / self.environment_name
         if cache_dir.exists() and cache_dir.is_dir():
             print(f"Using cached environment data from: {cache_dir}")
             return str(cache_dir)

--- a/hydrogym/jax/envs/channel.py
+++ b/hydrogym/jax/envs/channel.py
@@ -413,13 +413,18 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
 
     def __init__(self, env_config: Dict):
         super().__init__(env_config)
-        self.Lx = 2.0 * jnp.pi
-        self.Ly = 1.0 * jnp.pi
-        self.Lz = 2.0
-        self.nu = 1.9e-3
-        self.Nx = 72
-        self.Ny = 72
-        self.Nz = 72
+        # Physical/spectral grid parameters. Defaults preserve the previously
+        # hardcoded values exactly; env_config overrides exist for running
+        # other channel configurations (NOTE: non-default Nx/Ny/Nz change the
+        # JIT-compiled spectral operator shapes and require matching
+        # initial-field array shapes at reset()).
+        self.Lx = env_config.get("Lx", 2.0 * jnp.pi)
+        self.Ly = env_config.get("Ly", 1.0 * jnp.pi)
+        self.Lz = env_config.get("Lz", 2.0)
+        self.nu = env_config.get("nu", 1.9e-3)
+        self.Nx = int(env_config.get("Nx", 72))
+        self.Ny = int(env_config.get("Ny", 72))
+        self.Nz = int(env_config.get("Nz", 72))
 
         dtype_str = env_config.get("dtype", "float32")
         self.dtype = jnp.float64 if dtype_str == "float64" else jnp.float32
@@ -443,12 +448,16 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
         # Load initial fields from HuggingFace (downloaded/cached via HFDataManager).
         # env_config may override with:
         #   - "initial_field_dir": path to a directory containing U/V/W_nocontrol.npy
-        #   - "local_fallback_dir": passed to HFDataManager for offline use
+        #   - "hf_repo_id" / "cache_dir" / "use_clean_cache" / "local_fallback_dir":
+        #     forwarded to HFDataManager (defaults match JAXFlowEnv's).
         if "initial_field_dir" in env_config:
             initial_field_dir = Path(env_config["initial_field_dir"])
         else:
             dm = HFDataManager(
+                repo_id=env_config.get("hf_repo_id", "dynamicslab/HydroGym-environments"),
+                cache_dir=env_config.get("cache_dir"),
                 local_fallback_dir=env_config.get("local_fallback_dir"),
+                use_clean_cache=env_config.get("use_clean_cache", True),
                 fallback_profile="JAX",
             )
             env_path = dm.get_environment_path("Channel_3D_Retau180")

--- a/hydrogym/jax/envs/channel.py
+++ b/hydrogym/jax/envs/channel.py
@@ -459,6 +459,8 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
                 local_fallback_dir=env_config.get("local_fallback_dir"),
                 use_clean_cache=env_config.get("use_clean_cache", True),
                 fallback_profile="JAX",
+                token=env_config.get("hf_token"),
+                revision=env_config.get("hf_revision"),
             )
             env_path = dm.get_environment_path("Channel_3D_Retau180")
             initial_field_dir = Path(env_path) / "initial_field"

--- a/hydrogym/jax/envs/kolmogorov.py
+++ b/hydrogym/jax/envs/kolmogorov.py
@@ -30,12 +30,14 @@ class FlowConfig(PDEBase):
     DEFAULT_OBS_SIZE = 8  # This correlates to a total observation size of 8x8 = 64.
 
     def __init__(self, **config):
-        self.k = config.get("k", self.DEFAULT_WAVENUMBER)
-        self.Re = config.get("Re", self.DEFAULT_REYNOLDS)
-        self.grid_size = config.get("grid_size", self.DEFAULT_GRID_SIZE)
-        self.domain_x = config.get("domain_x", self.DEFAULT_DOMAIN_X)
-        self.domain_y = config.get("domain_y", self.DEFAULT_DOMAIN_Y)
-        self.obs_size = config.get("obs_size", self.DEFAULT_OBS_SIZE)
+        # Keys are popped (not just read) so PDEBase's unknown-key warning
+        # (audit Task 2.1) only fires on genuinely unknown options.
+        self.k = config.pop("k", self.DEFAULT_WAVENUMBER)
+        self.Re = config.pop("Re", self.DEFAULT_REYNOLDS)
+        self.grid_size = config.pop("grid_size", self.DEFAULT_GRID_SIZE)
+        self.domain_x = config.pop("domain_x", self.DEFAULT_DOMAIN_X)
+        self.domain_y = config.pop("domain_y", self.DEFAULT_DOMAIN_Y)
+        self.obs_size = config.pop("obs_size", self.DEFAULT_OBS_SIZE)
         self.control_function = (
             jnp.zeros_like(self.load_mesh("default")[0]),
             jnp.zeros_like(self.load_mesh("default")[1]),

--- a/hydrogym/jaxfluids/env_core.py
+++ b/hydrogym/jaxfluids/env_core.py
@@ -38,12 +38,16 @@ class JAXFluidsFlowEnv(JAXFluidsEnv):
         self.hf_repo_id = env_config.get("hf_repo_id", "dynamicslab/HydroGym-environments")
         self.local_fallback_dir = env_config.get("local_fallback_dir", None)
         self.use_clean_cache = env_config.get("use_clean_cache", True)
+        self.hf_token = env_config.get("hf_token", None)
+        self.hf_revision = env_config.get("hf_revision", None)
 
         self.data_manager = HFDataManager(
             repo_id=self.hf_repo_id,
             local_fallback_dir=self.local_fallback_dir,
             use_clean_cache=self.use_clean_cache,
             fallback_profile="JAXFLUIDS",
+            token=self.hf_token,
+            revision=self.hf_revision,
         )
 
         # Environment identification

--- a/hydrogym/maia/env_core.py
+++ b/hydrogym/maia/env_core.py
@@ -51,6 +51,36 @@ class MaiaFlowEnv(gym.Env):
 
     SOLVER_TYPE: str = "MAIA_LB"
 
+    @staticmethod
+    def _resolve_num_substeps(cfg_section) -> int:
+        """
+        Resolve the per-actuation substep count from the environment's YAML
+        config section (e.g. cfg.maia).
+
+        ``num_substeps`` is the primary key (matching Firedrake's
+        non-deprecated name and core.py's actuation_config); the old
+        ``num_sim_substeps_per_actuation`` key keeps working with a
+        DeprecationWarning.
+
+        Raises:
+            ConfigError: If the section defines neither key.
+        """
+        import warnings
+
+        if "num_substeps" in cfg_section:
+            return cfg_section["num_substeps"]
+        if "num_sim_substeps_per_actuation" in cfg_section:
+            warnings.warn(
+                "num_sim_substeps_per_actuation in the environment config is deprecated, rename it to num_substeps",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return cfg_section["num_sim_substeps_per_actuation"]
+        raise ConfigError(
+            "Environment config section defines neither 'num_substeps' nor (deprecated) "
+            "'num_sim_substeps_per_actuation'"
+        )
+
     def __init__(self, env_config: Dict):
         """
         Initialize the MaiaFlowEnv environment.
@@ -134,7 +164,7 @@ class MaiaFlowEnv(gym.Env):
 
         self.runtime_property_file = os.path.join(self.env_data_path, "properties_run.toml")
 
-        self.num_substeps_per_iteration = self.cfg.maia.num_sim_substeps_per_actuation
+        self.num_substeps_per_iteration = self._resolve_num_substeps(self.cfg.maia)
         self.observation_type = self.cfg.maia.observation_type
         self.max_episode_steps = self.cfg.env.max_episode_steps
         self.num_inputs = self.cfg.maia.num_action_inputs * self.cfg.env.n_agents

--- a/hydrogym/maia/env_core.py
+++ b/hydrogym/maia/env_core.py
@@ -107,12 +107,16 @@ class MaiaFlowEnv(gym.Env):
         self.hf_repo_id = env_config.get("hf_repo_id", "dynamicslab/HydroGym-environments")
         self.local_fallback_dir = env_config.get("local_fallback_dir", None)
         self.use_clean_cache = env_config.get("use_clean_cache", True)
+        self.hf_token = env_config.get("hf_token", None)
+        self.hf_revision = env_config.get("hf_revision", None)
 
         self.data_manager = HFDataManager(
             repo_id=self.hf_repo_id,
             local_fallback_dir=self.local_fallback_dir,
             use_clean_cache=self.use_clean_cache,
             fallback_profile=self.SOLVER_TYPE,
+            token=self.hf_token,
+            revision=self.hf_revision,
         )
 
         # Environment identification
@@ -953,17 +957,23 @@ def from_hf(environment_name: str, hf_repo_id: str = "dynamicslab/HydroGym-envir
         raise ConfigError(f"Failed to create environment '{environment_name}' of type '{env_type}': {e}") from e
 
 
-def list_available_environments(hf_repo_id: str = "dynamicslab/HydroGym-environments") -> List[str]:
+def list_available_environments(
+    hf_repo_id: str = "dynamicslab/HydroGym-environments",
+    hf_token: Optional[str] = None,
+    hf_revision: Optional[str] = None,
+) -> List[str]:
     """
     List all available environments from HF Hub.
 
     Args:
         hf_repo_id: Hugging Face repository ID.
+        hf_token: Hugging Face access token (private/gated repos; ``None`` = ambient auth).
+        hf_revision: Git revision to pin the file listing to.
 
     Returns:
         List of environment names.
     """
-    data_manager = HFDataManager(repo_id=hf_repo_id)
+    data_manager = HFDataManager(repo_id=hf_repo_id, token=hf_token, revision=hf_revision)
     return data_manager.get_available_environments()
 
 

--- a/hydrogym/maia/workspace.py
+++ b/hydrogym/maia/workspace.py
@@ -32,6 +32,8 @@ class MaiaWorkspace:
         local_fallback_dir: Optional[str] = None,
         use_clean_cache: bool = True,
         solver_type: Optional[str] = None,
+        hf_token: Optional[str] = None,
+        hf_revision: Optional[str] = None,
     ):
         """
         Initialize the MAIA workspace.
@@ -43,6 +45,8 @@ class MaiaWorkspace:
             local_fallback_dir: Optional local fallback directory.
             use_clean_cache: Whether to use clean cache for HF downloads.
             solver_type: Solver profile key (``'MAIA_LB'`` or ``'MAIA_STRCTRD'``).
+            hf_token: Hugging Face access token (private/gated repos; ``None`` = ambient auth).
+            hf_revision: Git revision to pin HF downloads/listings to.
                 Auto-detected from sentinel files if ``None`` (recommended).
                 Defaults to ``'MAIA_LB'`` as fallback for legacy environments.
         """
@@ -54,6 +58,8 @@ class MaiaWorkspace:
             local_fallback_dir=local_fallback_dir,
             use_clean_cache=use_clean_cache,
             fallback_profile=solver_type or "MAIA_LB",
+            token=hf_token,
+            revision=hf_revision,
         )
 
         self.env_data_path: Optional[str] = None

--- a/hydrogym/nek/env.py
+++ b/hydrogym/nek/env.py
@@ -224,11 +224,14 @@ class NekEnv(gym.Env):
             - run_name: Run name (auto-generate if None)
             - reward_agg: 'mean', 'sum', or 'median' (default: 'mean'); legacy name
             - reward_aggregation: same as reward_agg, primary name (takes precedence)
-            - normalize_input: Override normalization strategy
-            - nb_interactions: Override episode length
-            - random_init: Override IC randomization
-            - rescale_actions: Override action rescaling
-            - rew_mode: Override reward mode
+            - normalize_input: Override normalization strategy (shorthand)
+            - nb_interactions: Override episode length (shorthand)
+            - random_init: Override IC randomization (shorthand)
+            - rescale_actions: Override action rescaling (shorthand)
+            - rew_mode: Override reward mode (shorthand)
+            - '<section>.<param>': Override ANY existing config-tree entry by
+              dotted path (e.g. 'simulation.walltime'); unknown paths raise
+              ConfigError
 
         Returns:
           NekEnv instance
@@ -489,25 +492,78 @@ class NekEnv(gym.Env):
                     # Fallback: use configured path even if it doesn't exist yet
                     self.conf.simulation.restart_folder = os.path.join(self.env_data_path, restart_folder)
 
-    def _apply_runtime_overrides(self, env_config: Dict):
-        """Apply runtime overrides from env_config to loaded config."""
-        # Allow runtime override of certain parameters
-        override_map = {
-            "normalize_input": ("normalization", "normalize_input"),
-            "nb_interactions": ("episode", "max_interactions"),
-            "random_init": ("initial_conditions", "random_init"),
-            "rescale_actions": ("rl_interface", "rescale_actions"),
-            "rew_mode": ("episode", "reward_mode"),
+    # env_config keys that are consumed structurally by __init__/_init_from_hf
+    # (environment selection, HF/cache options, run layout, reward aggregation)
+    # and must never be interpreted as config-tree overrides.
+    RESERVED_ENV_CONFIG_KEYS = frozenset(
+        {
+            "environment_name",
+            "nproc",
+            "hostfile",
+            "hf_repo_id",
+            "use_clean_cache",
+            "local_fallback_dir",
+            "configuration_file",
+            "run_root",
+            "run_name",
+            "reward_agg",
+            "reward_aggregation",
+            "hf_token",
+            "hf_revision",
         }
+    )
 
-        for key, (section, param) in override_map.items():
-            if key in env_config:
-                # Check if section exists in config
-                if hasattr(self.conf, section):
-                    cfg_section = getattr(self.conf, section)
-                    if hasattr(cfg_section, param):
-                        setattr(cfg_section, param, env_config[key])
-                        print(f"[NEK] Override: {section}.{param} = {env_config[key]}")
+    # Legacy shorthand keys, mapped to the config-tree path they set. Kept
+    # working unchanged; the dotted path is the general form.
+    SHORTHAND_OVERRIDES = {
+        "normalize_input": ("normalization", "normalize_input"),
+        "nb_interactions": ("episode", "max_interactions"),
+        "random_init": ("initial_conditions", "random_init"),
+        "rescale_actions": ("rl_interface", "rescale_actions"),
+        "rew_mode": ("episode", "reward_mode"),
+    }
+
+    def _apply_runtime_overrides(self, env_config: Dict):
+        """Apply runtime overrides from env_config to the loaded config.
+
+        Two key forms are supported (anything else is a ConfigError, not a
+        silent drop):
+
+        - Dotted config-tree paths, e.g. ``{"episode.max_interactions": 5}``
+          or ``{"simulation.walltime": 100}``. The path must already exist
+          in the loaded configuration.
+        - The five legacy shorthand keys in SHORTHAND_OVERRIDES, which map
+          to the same tree paths and keep working unchanged.
+
+        Reserved structural keys (RESERVED_ENV_CONFIG_KEYS) are ignored here;
+        they configure the environment machinery itself, not the solver
+        config.
+        """
+        for key, value in env_config.items():
+            if key in self.RESERVED_ENV_CONFIG_KEYS:
+                continue
+            if key in self.SHORTHAND_OVERRIDES:
+                section, param = self.SHORTHAND_OVERRIDES[key]
+                path = f"{section}.{param}"
+            elif "." in key:
+                path = key
+            else:
+                raise ConfigError(
+                    f"Unknown env_config override key {key!r}. Use a dotted "
+                    "config path (e.g. 'episode.max_interactions') or one of "
+                    f"the shorthand keys {sorted(self.SHORTHAND_OVERRIDES)}."
+                )
+
+            section_path, _, param = path.rpartition(".")
+            parent = OmegaConf.select(self.conf, section_path) if section_path else self.conf
+            if parent is None or param not in parent:
+                raise ConfigError(
+                    f"Runtime override path {path!r} does not exist in the "
+                    f"configuration for '{self.environment_name}'. Check the "
+                    "environment's config file for the correct section.param."
+                )
+            parent[param] = value
+            print(f"[NEK] Override: {path} = {value}")
 
     def _get_config_value(self, *paths, default=None):
         """

--- a/hydrogym/nek/env.py
+++ b/hydrogym/nek/env.py
@@ -116,14 +116,17 @@ class NekEnv(gym.Env):
       configuration_file: Override config file path
       run_root: Root directory for outputs (default: 'runs')
       run_name: Name for this run (default: '' = no subdirectory, use run_root directly)
-      reward_agg: Reward aggregation method ("mean" or "sum")
+      reward_agg: Reward aggregation method ("mean", "sum", or "median") - legacy
+          name, kept working
+      reward_aggregation: Same as reward_agg, primary name (matches core.py /
+          Firedrake); takes precedence when both are given
       ... (runtime overrides for config parameters)
 
     Args (Legacy pattern):
       conf: Configuration object (OmegaConf)
       run_root: Root directory for run outputs
       run_name: Name for this run (defaults to MPI rank)
-      reward_agg: How to aggregate per-actuator rewards ("mean" or "sum")
+      reward_agg: How to aggregate per-actuator rewards ("mean", "sum", or "median")
     """
 
     metadata = {"render_modes": ["human"]}
@@ -136,6 +139,7 @@ class NekEnv(gym.Env):
         run_root: str = ".",
         run_name: Optional[str] = None,
         reward_agg: str = "mean",
+        reward_aggregation: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -152,6 +156,21 @@ class NekEnv(gym.Env):
         # Determine which API is being used
         if conf is not None and env_config is not None:
             raise ValueError("Cannot provide both 'conf' and 'env_config'. Use one or the other.")
+
+        # ``reward_aggregation`` is the primary name (matching core.py's
+        # actuation_config / Firedrake); ``reward_agg`` is the legacy Nek
+        # name and keeps working unchanged.
+        if reward_aggregation is not None:
+            if reward_agg != "mean" and reward_agg != reward_aggregation:
+                warnings.warn(
+                    "Both reward_agg and reward_aggregation were provided with different values; "
+                    "using reward_aggregation",
+                    stacklevel=2,
+                )
+            reward_agg = reward_aggregation
+        if reward_agg not in ("mean", "sum", "median"):
+            raise ValueError(f"reward aggregation must be 'mean', 'sum', or 'median', got {reward_agg!r}")
+        self.reward_agg = reward_agg
 
         if conf is not None:
             # Legacy API
@@ -188,7 +207,8 @@ class NekEnv(gym.Env):
             - configuration_file: Override config path
             - run_root: Output directory (default: 'runs')
             - run_name: Run name (auto-generate if None)
-            - reward_agg: 'mean' or 'sum' (default: 'mean')
+            - reward_agg: 'mean', 'sum', or 'median' (default: 'mean'); legacy name
+            - reward_aggregation: same as reward_agg, primary name (takes precedence)
             - normalize_input: Override normalization strategy
             - nb_interactions: Override episode length
             - random_init: Override IC randomization
@@ -256,7 +276,28 @@ class NekEnv(gym.Env):
         self.environment_name = env_config["environment_name"]
         self.nproc = env_config["nproc"]
         self.hostfile = env_config.get("hostfile", "")
-        self.reward_agg = reward_agg
+
+        # reward_agg/reward_aggregation may also arrive via env_config (e.g.
+        # through from_hf(**kwargs)); the from_hf docstring documented this
+        # override but it was previously SILENTLY IGNORED (only the
+        # __init__-level kwarg was ever read, which from_hf never forwards).
+        # The `reward_agg` argument here is the value already resolved in
+        # __init__ from the reward_agg/reward_aggregation kwargs, so it wins
+        # whenever it is not at its "mean" default; env_config overrides
+        # (from_hf kwargs) win over the bare default:
+        #   resolved kwarg (incl. reward_aggregation) > env_config
+        #   ["reward_aggregation"] > env_config["reward_agg"] > "mean".
+        if "reward_aggregation" in env_config:
+            cfg_reward = env_config["reward_aggregation"]
+        elif reward_agg != "mean":
+            cfg_reward = reward_agg
+        elif "reward_agg" in env_config:
+            cfg_reward = env_config["reward_agg"]
+        else:
+            cfg_reward = reward_agg
+        if cfg_reward not in ("mean", "sum", "median"):
+            raise ValueError(f"reward aggregation must be 'mean', 'sum', or 'median', got {cfg_reward!r}")
+        self.reward_agg = cfg_reward
 
         # Initialize HF data manager
         self.hf_repo_id = env_config.get("hf_repo_id", "dynamicslab/HydroGym-environments")
@@ -780,6 +821,8 @@ class NekEnv(gym.Env):
         # Aggregate reward
         if self.reward_agg == "sum":
             reward = float(np.sum(rewards_per_actuator))
+        elif self.reward_agg == "median":
+            reward = float(np.median(rewards_per_actuator))
         else:  # mean
             reward = float(np.mean(rewards_per_actuator))
 

--- a/hydrogym/nek/env.py
+++ b/hydrogym/nek/env.py
@@ -303,12 +303,16 @@ class NekEnv(gym.Env):
         self.hf_repo_id = env_config.get("hf_repo_id", "dynamicslab/HydroGym-environments")
         self.local_fallback_dir = env_config.get("local_fallback_dir", None)
         self.use_clean_cache = env_config.get("use_clean_cache", True)
+        self.hf_token = env_config.get("hf_token", None)
+        self.hf_revision = env_config.get("hf_revision", None)
 
         self.data_manager = HFDataManager(
             repo_id=self.hf_repo_id,
             local_fallback_dir=self.local_fallback_dir,
             use_clean_cache=self.use_clean_cache,
             fallback_profile=self.SOLVER_TYPE,
+            token=self.hf_token,
+            revision=self.hf_revision,
         )
 
         # Download/get environment data

--- a/hydrogym/nek/env.py
+++ b/hydrogym/nek/env.py
@@ -152,10 +152,25 @@ class NekEnv(gym.Env):
           run_name: Run name (auto-generate if None)
           reward_agg: Reward aggregation method
           **kwargs: Additional parameters (for backward compatibility)
+
+        Raises:
+          ValueError: If both 'conf' and 'env_config' are given, or an invalid
+            reward aggregation is requested.
+          UserWarning: If **kwargs is non-empty -- these are accepted for
+            backward compatibility but have NO effect; runtime overrides
+            belong in env_config (see NekEnv.from_hf).
         """
         # Determine which API is being used
         if conf is not None and env_config is not None:
             raise ValueError("Cannot provide both 'conf' and 'env_config'. Use one or the other.")
+
+        if kwargs:
+            warnings.warn(
+                f"NekEnv.__init__ got unsupported keyword argument(s) {sorted(kwargs)}; "
+                "they have no effect. Runtime configuration overrides belong in "
+                "env_config (see NekEnv.from_hf).",
+                stacklevel=2,
+            )
 
         # ``reward_aggregation`` is the primary name (matching core.py's
         # actuation_config / Firedrake); ``reward_agg`` is the legacy Nek

--- a/hydrogym/nek/env.py
+++ b/hydrogym/nek/env.py
@@ -110,6 +110,8 @@ class NekEnv(gym.Env):
       environment_name: Name of environment on HuggingFace
       nproc: Number of MPI workers for Nek (required)
       hostfile: MPI hostfile path (default: '')
+      mpi_bind_to: MPI bind policy passed to mpirun via MPI.Info
+          (default: 'none' = unbound; e.g. 'core' binds ranks to cores)
       hf_repo_id: HuggingFace repository (default: 'dynamicslab/HydroGym-environments')
       use_clean_cache: Use fresh workspace (default: True)
       local_fallback_dir: Local directory for offline usage
@@ -131,6 +133,9 @@ class NekEnv(gym.Env):
 
     metadata = {"render_modes": ["human"]}
     SOLVER_TYPE = "NEK5000"
+    # MPI rank-binding policy passed to mpirun via MPI.Info ("bind_to").
+    # Overridable via the `mpi_bind_to` env_config key (MAIA pattern).
+    DEFAULT_MPI_BIND_TO = "none"
 
     def __init__(
         self,
@@ -323,6 +328,7 @@ class NekEnv(gym.Env):
         self.use_clean_cache = env_config.get("use_clean_cache", True)
         self.hf_token = env_config.get("hf_token", None)
         self.hf_revision = env_config.get("hf_revision", None)
+        self.mpi_bind_to = env_config.get("mpi_bind_to", self.DEFAULT_MPI_BIND_TO)
 
         self.data_manager = HFDataManager(
             repo_id=self.hf_repo_id,
@@ -510,6 +516,7 @@ class NekEnv(gym.Env):
             "reward_aggregation",
             "hf_token",
             "hf_revision",
+            "mpi_bind_to",
         }
     )
 
@@ -620,7 +627,7 @@ class NekEnv(gym.Env):
         # MPI info for Nek
         mpi_info = MPI.Info.Create()
         mpi_info.Set("wdir", f"{os.getcwd()}/{self.run_folder}")
-        mpi_info.Set("bind_to", "none")
+        mpi_info.Set("bind_to", getattr(self, "mpi_bind_to", self.DEFAULT_MPI_BIND_TO))
         if self.hostfile and self.hostfile != "":
             mpi_info.Set("hostfile", self.hostfile)
             print("[NEK] LOAD HOSTFILE!")

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -179,6 +179,32 @@ class TestPDEBaseConstruction:
         with pytest.raises(ValueError, match="restart must be a string or list"):
             MockFlow(restart=5)
 
+    # -- unknown-key warning (audit Task 2.1) --------------------------------
+
+    def test_unknown_config_key_warns(self):
+        """Keys no subclass consumed reach PDEBase and must warn, not be
+        silently dropped (the audit's Finding: misspelled options vanished)."""
+        with pytest.warns(UserWarning, match="unrecognized_option") as record:
+            MockFlow(unrecognized_option=3)
+        assert any("no effect" in str(w.message) for w in record)
+
+    def test_valid_config_keys_raise_no_warning(self):
+        """All consumed keys (subclass-level, mesh, restart) must stay
+        warning-free -- this must never become a hard error for valid
+        Firedrake flow configs."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            flow = MockFlow(initial_condition=5.0, mesh="foo.mesh", restart="ckpt_a")
+        assert flow.q == 10.0
+
+    def test_unknown_key_does_not_break_construction(self):
+        """Warning, not error: construction still succeeds."""
+        with pytest.warns(UserWarning):
+            flow = MockFlow(Re=100)  # e.g. a key a backend doesn't consume
+        assert flow.q == 1.0
+
     def test_reset_sets_state_and_time(self):
         flow = MockFlow()
         flow.q = 42.0

--- a/test/test_hf_data_manager_cache_dir.py
+++ b/test/test_hf_data_manager_cache_dir.py
@@ -1,0 +1,100 @@
+"""Unit tests for audit Task 2.5: `cache_dir` forwarded to `snapshot_download`.
+
+Before this change, none of HFDataManager's three `snapshot_download()` call
+sites passed `cache_dir`, so raw HF downloads always landed in the
+huggingface_hub default cache (~/.cache/huggingface) regardless of the
+`cache_dir` the user configured -- a problem on quota-limited HPC home dirs.
+
+Deliberate deviation from the audit's literal spec ("pass
+`cache_dir=self.cache_dir`"): `self.cache_dir` is never None (it defaults to
+~/.cache/hydrogym), so forwarding it unconditionally would move EVERY user's
+HF download cache and orphan existing downloads. Instead only an
+explicitly-provided `cache_dir` is forwarded; the default case preserves the
+previous download location exactly. The clean-cache symlink/copy layer
+(``self.cache_dir``) is untouched in both cases.
+
+All three caching strategies (symlink / copy / direct) are exercised through
+the real `get_environment_path` dispatch with `snapshot_download` mocked --
+no network, no real HF cache.
+
+pytest.importorskip guards: hydrogym.data_manager imports huggingface_hub.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("huggingface_hub")
+
+from hydrogym import data_manager as dm_mod  # noqa: E402
+from hydrogym.data_manager import HFDataManager  # noqa: E402
+
+ENV_NAME = "TestEnv"
+
+
+@pytest.fixture
+def fake_hf_snapshot(tmp_path, monkeypatch):
+    """Fake snapshot_download: records kwargs and materializes a snapshot dir
+    under the cache_dir it was given (mirroring the real function's cache
+    layout), holding one environment (JAXFLUIDS profile: no required files,
+    sentinel only)."""
+    calls = []
+
+    def fake_snapshot_download(**kwargs):
+        calls.append(kwargs)
+        root = kwargs.get("cache_dir") or (tmp_path / "hf_default_cache")
+        snapshot_dir = Path(root) / "datasets--t--r" / "snapshots" / "abc123"
+        env_dir = snapshot_dir / ENV_NAME
+        env_dir.mkdir(parents=True, exist_ok=True)
+        (env_dir / ".JAXFLUIDS").write_text("")
+        return str(snapshot_dir)
+
+    monkeypatch.setattr(dm_mod, "snapshot_download", fake_snapshot_download)
+    # Skip _detect_solver_profile's HF file-listing (network); the profile
+    # under test is pinned to JAXFLUIDS, whose validation is a no-op.
+    monkeypatch.setattr(HFDataManager, "_detect_solver_profile", lambda self, env: "JAXFLUIDS")
+    return calls
+
+
+class TestExplicitCacheDirForwarded:
+    @pytest.mark.parametrize("use_clean_cache", [True, "copy", False])
+    def test_all_three_strategies_forward_cache_dir(self, fake_hf_snapshot, tmp_path, use_clean_cache):
+        clean_cache = tmp_path / "clean_cache"
+        dm = HFDataManager(
+            repo_id="t/r",
+            cache_dir=str(clean_cache),
+            use_clean_cache=use_clean_cache,
+            fallback_profile="JAXFLUIDS",
+        )
+        path = dm.get_environment_path(ENV_NAME, force_download=True)
+
+        assert len(fake_hf_snapshot) == 1
+        assert fake_hf_snapshot[0]["cache_dir"] == str(clean_cache)
+        assert os.path.exists(path)  # env usable whichever strategy ran
+
+    def test_forwarded_dir_receives_download(self, fake_hf_snapshot, tmp_path):
+        """End-to-end: the snapshot path the mock 'downloaded to' sits under
+        the configured cache_dir (what a user on a quota-limited home dir
+        would point at scratch)."""
+        scratch = tmp_path / "scratch"
+        dm = HFDataManager(
+            repo_id="t/r",
+            cache_dir=str(scratch),
+            use_clean_cache=False,
+            fallback_profile="JAXFLUIDS",
+        )
+        path = dm.get_environment_path(ENV_NAME, force_download=True)
+        assert os.path.realpath(path).startswith(str(scratch) + os.sep)
+
+
+class TestDefaultBehaviorUnchanged:
+    def test_no_cache_dir_passed_keeps_hf_default(self, fake_hf_snapshot, tmp_path):
+        """Omitting cache_dir must preserve the pre-change behavior: no
+        cache_dir kwarg forwarded, so snapshot_download uses the
+        huggingface_hub default cache. (use_clean_cache=False avoids creating
+        the real ~/.cache/hydrogym from __init__.)"""
+        dm = HFDataManager(repo_id="t/r", use_clean_cache=False, fallback_profile="JAXFLUIDS")
+        dm.get_environment_path(ENV_NAME, force_download=True)
+
+        assert fake_hf_snapshot[0]["cache_dir"] is None

--- a/test/test_hf_data_manager_token_revision.py
+++ b/test/test_hf_data_manager_token_revision.py
@@ -1,0 +1,269 @@
+"""Unit tests for audit Task 2.6: `token`/`revision` on HFDataManager.
+
+Previously there was no HydroGym API surface for private/gated HF repos or
+for pinning a revision -- only ambient auth (HF_TOKEN / huggingface-cli
+login) and the repo's default branch worked. Now:
+
+- HFDataManager.__init__ takes optional token=/revision= and threads them
+  into every huggingface_hub call (3x snapshot_download, 2x list_repo_files).
+- Every backend that constructs its own HFDataManager exposes
+  hf_token/hf_revision env_config keys (maia/jax/jaxfluids/nek env_core,
+  maia workspace, jax channel initial-field loader) or flow_config keys
+  (firedrake checkpoint resolver) and forwards them.
+
+Omitting the new kwargs must preserve ambient-auth behavior exactly:
+huggingface_hub treats token=None as "use ambient credentials", so
+forwarding None is byte-identical to not forwarding.
+
+pytest.importorskip guards: huggingface_hub (data_manager), mpi4py+pandas
+(NekEnv behavioral test), firedrake / backend modules (heavier imports).
+"""
+
+import inspect
+
+import pytest
+
+pytest.importorskip("huggingface_hub")
+
+from hydrogym import data_manager as dm_mod  # noqa: E402
+from hydrogym.data_manager import HFDataManager  # noqa: E402
+
+ENV_NAME = "TestEnv"
+
+
+@pytest.fixture
+def recording_hf(monkeypatch, tmp_path):
+    """Mock both HF entry points used by data_manager; record their kwargs.
+
+    snapshot_download materializes a minimal JAXFLUIDS-profile env (sentinel
+    only, no required files) under the returned snapshot dir; list_repo_files
+    is recorded and returns just the sentinel path so profile detection works
+    without network.
+    """
+    snapshot_calls = []
+    api_calls = []
+
+    snapshot_dir = tmp_path / "hf" / "datasets--t--r" / "snapshots" / "abc123"
+    env_dir = snapshot_dir / ENV_NAME
+    env_dir.mkdir(parents=True)
+    (env_dir / ".JAXFLUIDS").write_text("")
+
+    def fake_snapshot_download(**kwargs):
+        snapshot_calls.append(kwargs)
+        return str(snapshot_dir)
+
+    class FakeApi:
+        def __init__(self, **kwargs):
+            api_calls.append(("HfApi", kwargs))
+
+        def list_repo_files(self, repo_id, repo_type=None, revision=None):
+            api_calls.append(("list_repo_files", {"repo_id": repo_id, "repo_type": repo_type, "revision": revision}))
+            return [f"{ENV_NAME}/.JAXFLUIDS"]
+
+    monkeypatch.setattr(dm_mod, "snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr(dm_mod, "HfApi", FakeApi)
+    return snapshot_calls, api_calls
+
+
+class TestDataManagerThreading:
+    def test_snapshot_download_receives_token_and_revision(self, recording_hf, tmp_path):
+        snapshot_calls, _ = recording_hf
+        dm = HFDataManager(
+            repo_id="t/r",
+            cache_dir=str(tmp_path / "clean"),
+            use_clean_cache=False,
+            fallback_profile="JAXFLUIDS",
+            token="hf_tok_123",
+            revision="v1.2.3",
+        )
+        dm.get_environment_path(ENV_NAME, force_download=True)
+
+        assert len(snapshot_calls) == 1
+        assert snapshot_calls[0]["token"] == "hf_tok_123"
+        assert snapshot_calls[0]["revision"] == "v1.2.3"
+
+    @pytest.mark.parametrize("use_clean_cache", [True, "copy", False])
+    def test_all_three_download_strategies_thread(self, recording_hf, tmp_path, use_clean_cache):
+        snapshot_calls, _ = recording_hf
+        dm = HFDataManager(
+            repo_id="t/r",
+            cache_dir=str(tmp_path / "clean"),
+            use_clean_cache=use_clean_cache,
+            fallback_profile="JAXFLUIDS",
+            token="tok",
+            revision="rev",
+        )
+        dm.get_environment_path(ENV_NAME, force_download=True)
+        assert snapshot_calls[0]["token"] == "tok"
+        assert snapshot_calls[0]["revision"] == "rev"
+
+    def test_list_repo_files_receives_token_and_revision(self, recording_hf):
+        """Profile detection goes through HfApi(token=...).list_repo_files(
+        repo_id, repo_type, revision=...)."""
+        _, api_calls = recording_hf
+        dm = HFDataManager(repo_id="t/r", use_clean_cache=False, fallback_profile="JAXFLUIDS", token="tok", revision="rev")
+        profile = dm._detect_solver_profile(ENV_NAME)
+        assert profile == "JAXFLUIDS"
+
+        api_init = [k for name, k in api_calls if name == "HfApi"]
+        assert api_init and api_init[0].get("token") == "tok"
+        listings = [k for name, k in api_calls if name == "list_repo_files"]
+        assert listings and listings[0]["revision"] == "rev"
+
+    def test_get_available_environments_receives_token_and_revision(self, recording_hf):
+        _, api_calls = recording_hf
+        dm = HFDataManager(repo_id="t/r", use_clean_cache=False, fallback_profile="JAXFLUIDS", token="tok", revision="rev")
+        dm.get_available_environments()
+
+        listings = [k for name, k in api_calls if name == "list_repo_files"]
+        assert listings and listings[0]["revision"] == "rev"
+        api_init = [k for name, k in api_calls if name == "HfApi"]
+        assert api_init[0].get("token") == "tok"
+
+    def test_omitted_preserves_ambient_behavior(self, recording_hf, tmp_path):
+        """token=None/revision=None must be forwarded (huggingface_hub treats
+        None as ambient auth) -- i.e. exactly the pre-change effective call."""
+        snapshot_calls, api_calls = recording_hf
+        dm = HFDataManager(repo_id="t/r", cache_dir=str(tmp_path / "c"), use_clean_cache=False, fallback_profile="JAXFLUIDS")
+        dm.get_environment_path(ENV_NAME, force_download=True)
+        assert snapshot_calls[0]["token"] is None
+        assert snapshot_calls[0]["revision"] is None
+
+        dm._detect_solver_profile(ENV_NAME)
+        api_init = [k for name, k in api_calls if name == "HfApi"]
+        assert api_init[0].get("token") is None
+        listings = [k for name, k in api_calls if name == "list_repo_files"]
+        assert listings[0]["revision"] is None
+
+
+class TestNekEnvConfigThreading:
+    """Behavioral check for one backend's env_config -> HFDataManager path
+    (Nek's _init_from_hf, stubbed the same way as test_nek_reward_aggregation).
+    The remaining backends share the identical constructor pattern and are
+    covered by the source-drift guard below."""
+
+    @pytest.fixture
+    def nek_env_ctx(self, monkeypatch, tmp_path):
+        pytest.importorskip("mpi4py")
+        pytest.importorskip("pandas")
+        from hydrogym.nek import env as nek_env_mod
+
+        recorded = {}
+
+        class RecordingDataManager:
+            def __init__(self, *args, **kwargs):
+                recorded.update(kwargs)
+
+        (tmp_path / "config.yaml").write_text("env: {}\n")
+        monkeypatch.setattr(nek_env_mod, "HFDataManager", RecordingDataManager)
+        monkeypatch.setattr(nek_env_mod.NekEnv, "_setup_environment_data", lambda self: str(tmp_path))
+        monkeypatch.setattr(nek_env_mod.NekEnv, "_resolve_configuration_file", lambda self, x: str(tmp_path / "config.yaml"))
+        monkeypatch.setattr(nek_env_mod.NekEnv, "_update_configuration_paths", lambda self: None)
+        monkeypatch.setattr(nek_env_mod.NekEnv, "_apply_runtime_overrides", lambda self, ec: None)
+        monkeypatch.setattr(nek_env_mod.NekEnv, "_create_session_file_early", lambda self: None)
+        monkeypatch.setattr(nek_env_mod, "mpi_split", lambda comm, nproc=None: None)
+        monkeypatch.setattr(nek_env_mod.NekEnv, "_initialize", lambda self: None)
+        monkeypatch.chdir(tmp_path)
+        return {"recorded": recorded, "NekEnv": nek_env_mod.NekEnv}
+
+    def test_hf_token_and_revision_forwarded(self, nek_env_ctx):
+        env = nek_env_ctx["NekEnv"](
+            env_config={"environment_name": "x", "nproc": 1, "hf_token": "tok", "hf_revision": "rev"}
+        )
+        assert env.hf_token == "tok"
+        assert env.hf_revision == "rev"
+        assert nek_env_ctx["recorded"]["token"] == "tok"
+        assert nek_env_ctx["recorded"]["revision"] == "rev"
+
+    def test_omitted_keeps_defaults(self, nek_env_ctx):
+        env = nek_env_ctx["NekEnv"](env_config={"environment_name": "x", "nproc": 1})
+        assert env.hf_token is None
+        assert env.hf_revision is None
+        assert nek_env_ctx["recorded"]["token"] is None
+        assert nek_env_ctx["recorded"]["revision"] is None
+
+
+class TestBackendThreadingDriftGuard:
+    """Source-level guard: every backend env_core that builds its own
+    HFDataManager must (a) read hf_token/hf_revision from env_config and
+    (b) forward token=/revision= into the HFDataManager call. Behavioral
+    coverage exists for the data_manager layer and for NekEnv; this pins the
+    copy-paste family so a future new backend (or an accidental revert) can't
+    silently drop the keys. Modules whose heavy deps (jax, jaxfluids, mpi4py)
+    are absent simply skip."""
+
+    @pytest.mark.parametrize(
+        "module",
+        ["hydrogym.maia.env_core", "hydrogym.jax.env_core", "hydrogym.jaxfluids.env_core"],
+    )
+    def test_env_core_forwards_token_revision(self, module):
+        pytest.importorskip(module)
+        src = inspect.getsource(__import__(module, fromlist=["*"]))
+        assert 'env_config.get("hf_token"' in src, f"{module} does not read hf_token from env_config"
+        assert 'env_config.get("hf_revision"' in src, f"{module} does not read hf_revision from env_config"
+        assert "token=self.hf_token" in src, f"{module} does not forward token to HFDataManager"
+        assert "revision=self.hf_revision" in src, f"{module} does not forward revision to HFDataManager"
+
+
+class TestFiredrakeCheckpointResolver:
+    """flow_config hf_token/hf_revision must reach the checkpoint resolver's
+    HFDataManager. Called on a bare instance (no firedrake flow construction --
+    that path is broken at baseline) since _resolve_single_checkpoint only
+    uses its arguments."""
+
+    @staticmethod
+    def _bare_flow_cls():
+        """Minimal concrete FlowConfig: object.__new__ refuses abstract
+        classes, but the resolver methods only touch their arguments."""
+        from hydrogym.firedrake.flow import FlowConfig
+
+        class _StubFlow(FlowConfig):
+            def evaluate_objective(self):
+                pass
+
+            def init_bcs(self):
+                pass
+
+            def num_inputs(self):
+                return 0
+
+            def render(self):
+                pass
+
+        return _StubFlow
+
+    @staticmethod
+    def _install_recorder(monkeypatch, tmp_path, recorded):
+        class RecordingDataManager:
+            def __init__(self, *args, **kwargs):
+                recorded.update(kwargs)
+
+            def get_environment_path(self, name, force_download=False):
+                d = tmp_path / "env"
+                d.mkdir(exist_ok=True)
+                (d / "checkpoint0.h5").write_text("")  # happy path: resolver finds a ckpt
+                return str(d)
+
+        monkeypatch.setattr(dm_mod, "HFDataManager", RecordingDataManager)
+
+    def test_flow_config_keys_reach_hf_data_manager(self, monkeypatch, tmp_path):
+        pytest.importorskip("firedrake")
+        from hydrogym.firedrake.flow import FlowConfig
+
+        recorded = {}
+        self._install_recorder(monkeypatch, tmp_path, recorded)
+        flow = object.__new__(self._bare_flow_cls())
+        flow._resolve_single_checkpoint("SomeEnv", cache_dir=None, local_dir=None, hf_token="tok", hf_revision="rev")
+        assert recorded["token"] == "tok"
+        assert recorded["revision"] == "rev"
+
+    def test_omitted_keeps_ambient_behavior(self, monkeypatch, tmp_path):
+        pytest.importorskip("firedrake")
+        from hydrogym.firedrake.flow import FlowConfig
+
+        recorded = {}
+        self._install_recorder(monkeypatch, tmp_path, recorded)
+        flow = object.__new__(self._bare_flow_cls())
+        flow._resolve_single_checkpoint("SomeEnv")
+        assert recorded["token"] is None
+        assert recorded["revision"] is None

--- a/test/test_hf_data_manager_token_revision.py
+++ b/test/test_hf_data_manager_token_revision.py
@@ -101,7 +101,9 @@ class TestDataManagerThreading:
         """Profile detection goes through HfApi(token=...).list_repo_files(
         repo_id, repo_type, revision=...)."""
         _, api_calls = recording_hf
-        dm = HFDataManager(repo_id="t/r", use_clean_cache=False, fallback_profile="JAXFLUIDS", token="tok", revision="rev")
+        dm = HFDataManager(
+            repo_id="t/r", use_clean_cache=False, fallback_profile="JAXFLUIDS", token="tok", revision="rev"
+        )
         profile = dm._detect_solver_profile(ENV_NAME)
         assert profile == "JAXFLUIDS"
 
@@ -112,7 +114,9 @@ class TestDataManagerThreading:
 
     def test_get_available_environments_receives_token_and_revision(self, recording_hf):
         _, api_calls = recording_hf
-        dm = HFDataManager(repo_id="t/r", use_clean_cache=False, fallback_profile="JAXFLUIDS", token="tok", revision="rev")
+        dm = HFDataManager(
+            repo_id="t/r", use_clean_cache=False, fallback_profile="JAXFLUIDS", token="tok", revision="rev"
+        )
         dm.get_available_environments()
 
         listings = [k for name, k in api_calls if name == "list_repo_files"]
@@ -124,7 +128,9 @@ class TestDataManagerThreading:
         """token=None/revision=None must be forwarded (huggingface_hub treats
         None as ambient auth) -- i.e. exactly the pre-change effective call."""
         snapshot_calls, api_calls = recording_hf
-        dm = HFDataManager(repo_id="t/r", cache_dir=str(tmp_path / "c"), use_clean_cache=False, fallback_profile="JAXFLUIDS")
+        dm = HFDataManager(
+            repo_id="t/r", cache_dir=str(tmp_path / "c"), use_clean_cache=False, fallback_profile="JAXFLUIDS"
+        )
         dm.get_environment_path(ENV_NAME, force_download=True)
         assert snapshot_calls[0]["token"] is None
         assert snapshot_calls[0]["revision"] is None
@@ -157,7 +163,9 @@ class TestNekEnvConfigThreading:
         (tmp_path / "config.yaml").write_text("env: {}\n")
         monkeypatch.setattr(nek_env_mod, "HFDataManager", RecordingDataManager)
         monkeypatch.setattr(nek_env_mod.NekEnv, "_setup_environment_data", lambda self: str(tmp_path))
-        monkeypatch.setattr(nek_env_mod.NekEnv, "_resolve_configuration_file", lambda self, x: str(tmp_path / "config.yaml"))
+        monkeypatch.setattr(
+            nek_env_mod.NekEnv, "_resolve_configuration_file", lambda self, x: str(tmp_path / "config.yaml")
+        )
         monkeypatch.setattr(nek_env_mod.NekEnv, "_update_configuration_paths", lambda self: None)
         monkeypatch.setattr(nek_env_mod.NekEnv, "_apply_runtime_overrides", lambda self, ec: None)
         monkeypatch.setattr(nek_env_mod.NekEnv, "_create_session_file_early", lambda self: None)

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -101,3 +101,17 @@ class TestRealMethodsSupportKwarg:
     @pytest.mark.parametrize("solver_cls", [SemiImplicitBDF, LinearizedBDF])
     def test_solve_signature_has_collect_rewards(self, solver_cls):
         assert "collect_rewards" in inspect.signature(solver_cls.solve).parameters
+
+
+class TestNoiseKwargsRemoved:
+    """Task 2.3: NavierStokesTransientSolver's eta/max_noise_iter/noise_cutoff
+    accepted a white-noise body forcing whose implementation was removed
+    upstream (a067781, "Clean up old forcing code", 2024-03); the kwargs were
+    silently ignored ever since -- even by test_step.py, which passed eta=1.0
+    expecting forcing that never happened. They are removed; this pins the
+    removal so they can't silently reappear as dead parameters."""
+
+    @pytest.mark.parametrize("kwarg", ["eta", "max_noise_iter", "noise_cutoff"])
+    @pytest.mark.parametrize("solver_cls", [SemiImplicitBDF, LinearizedBDF])
+    def test_dead_noise_kwargs_gone(self, solver_cls, kwarg):
+        assert kwarg not in inspect.signature(solver_cls.__init__).parameters

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -69,9 +69,7 @@ class TestCollectRewardsForwarding:
         assert result is fake_method  # not a (flow, rewards) tuple
 
     def test_collect_rewards_returns_tuple(self, fake_method):
-        flow, rewards = integrate_fn(
-            fake_method, t_span=(0.0, 1.0), dt=0.25, collect_rewards=True, method="FakeBDF"
-        )
+        flow, rewards = integrate_fn(fake_method, t_span=(0.0, 1.0), dt=0.25, collect_rewards=True, method="FakeBDF")
         assert flow is fake_method
         assert isinstance(rewards, np.ndarray)
         assert rewards.shape == (n_steps((0.0, 1.0), 0.25),)
@@ -80,9 +78,7 @@ class TestCollectRewardsForwarding:
 
     def test_rewards_match_num_steps(self, fake_method):
         t_span = (0.0, 0.5)
-        _, rewards = integrate_fn(
-            fake_method, t_span=t_span, dt=0.1, collect_rewards=True, method="FakeBDF"
-        )
+        _, rewards = integrate_fn(fake_method, t_span=t_span, dt=0.1, collect_rewards=True, method="FakeBDF")
         assert len(rewards) == n_steps(t_span, 0.1)
 
 

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -1,0 +1,103 @@
+"""Unit tests for audit Task 2.4: `integrate()` forwards `collect_rewards`.
+
+`hydrogym.firedrake.solvers.integrate.integrate()` previously had no way to
+request reward collection even though the underlying
+`core.TransientSolver.solve` (which both METHODS entries inherit -- neither
+SemiImplicitBDF nor LinearizedBDF overrides `solve`) already supported
+`collect_rewards`. These tests pin the forwarding.
+
+The tests intentionally do NOT construct real Firedrake flows: flow
+construction currently fails in this repo's pinned Firedrake environment
+(dual_evaluation version skew, see test/README.md and the Task 0.3
+baseline). Instead, a fake solver is registered into the module-level
+METHODS dict, which is the extension point `integrate()` itself dispatches
+through -- the forwarding logic under test needs nothing more.
+
+pytest.importorskip guards: hydrogym.firedrake pulls in firedrake.
+"""
+
+import importlib
+import inspect
+
+import numpy as np
+import pytest
+
+pytest.importorskip("firedrake")
+
+from hydrogym import core  # noqa: E402
+from hydrogym.firedrake.solvers import bdf_ext  # noqa: E402
+from hydrogym.firedrake.solvers.bdf_ext import LinearizedBDF, SemiImplicitBDF  # noqa: E402
+
+# The `solvers` package re-exports the `integrate` FUNCTION under the same
+# name as its submodule, so `from ... import integrate` would bind the
+# function -- import the module explicitly.
+integrate_mod = importlib.import_module("hydrogym.firedrake.solvers.integrate")  # noqa: E402
+integrate_fn = integrate_mod.integrate  # noqa: E402
+
+
+class FakeFlow:
+    """Minimal stand-in for a PDEBase: enough for core.TransientSolver.solve."""
+
+    DEFAULT_DT = 0.1
+
+    def __init__(self):
+        self.t = 0.0
+
+    def evaluate_objective(self):
+        return self.t
+
+
+class FakeSolver(core.TransientSolver):
+    def step(self, iter, control=None, **kwargs):
+        self.flow.t += self.dt
+        return self.flow
+
+
+@pytest.fixture
+def fake_method(monkeypatch):
+    monkeypatch.setitem(integrate_mod.METHODS, "FakeBDF", FakeSolver)
+    return FakeFlow()
+
+
+def n_steps(t_span, dt):
+    return len(np.arange(*t_span, dt))
+
+
+class TestCollectRewardsForwarding:
+    def test_default_returns_flow_only(self, fake_method):
+        result = integrate_fn(fake_method, t_span=(0.0, 1.0), dt=0.25, method="FakeBDF")
+        assert result is fake_method  # not a (flow, rewards) tuple
+
+    def test_collect_rewards_returns_tuple(self, fake_method):
+        flow, rewards = integrate_fn(
+            fake_method, t_span=(0.0, 1.0), dt=0.25, collect_rewards=True, method="FakeBDF"
+        )
+        assert flow is fake_method
+        assert isinstance(rewards, np.ndarray)
+        assert rewards.shape == (n_steps((0.0, 1.0), 0.25),)
+        # core.solve evaluates the objective AFTER each step
+        np.testing.assert_allclose(rewards, [0.25, 0.5, 0.75, 1.0])
+
+    def test_rewards_match_num_steps(self, fake_method):
+        t_span = (0.0, 0.5)
+        _, rewards = integrate_fn(
+            fake_method, t_span=t_span, dt=0.1, collect_rewards=True, method="FakeBDF"
+        )
+        assert len(rewards) == n_steps(t_span, 0.1)
+
+
+class TestMethodValidation:
+    def test_invalid_method_still_rejected(self, fake_method):
+        with pytest.raises(ValueError, match="must be one of"):
+            integrate_fn(fake_method, t_span=(0.0, 1.0), dt=0.25, method="RK45")
+
+
+class TestRealMethodsSupportKwarg:
+    """Guard against drift: the real METHODS entries must keep accepting
+    collect_rewards (they inherit solve from core.TransientSolver; if either
+    class grows its own solve() without the kwarg, integrate()'s forwarding
+    would break at runtime)."""
+
+    @pytest.mark.parametrize("solver_cls", [SemiImplicitBDF, LinearizedBDF])
+    def test_solve_signature_has_collect_rewards(self, solver_cls):
+        assert "collect_rewards" in inspect.signature(solver_cls.solve).parameters

--- a/test/test_jax_channel_env.py
+++ b/test/test_jax_channel_env.py
@@ -50,9 +50,7 @@ class TestEnvConfigOverrides:
         constructed PseudoSpectralNavierStokes3D."""
         from hydrogym.jax.envs.channel import ChannelFlowSpectralEnv
 
-        env = ChannelFlowSpectralEnv(
-            {"initial_field_dir": str(synthetic_field_dir), "Nx": 48, "Ny": 48, "Nz": 48}
-        )
+        env = ChannelFlowSpectralEnv({"initial_field_dir": str(synthetic_field_dir), "Nx": 48, "Ny": 48, "Nz": 48})
 
         assert env.Nx == 48
         assert env.equation.Nx == 48 and env.equation.Ny == 48 and env.equation.Nz == 48
@@ -108,7 +106,7 @@ class TestHFConfigKeys:
         HFDataManager."""
         from hydrogym.jax.envs.channel import ChannelFlowSpectralEnv
 
-        env = ChannelFlowSpectralEnv(
+        ChannelFlowSpectralEnv(
             {
                 "hf_repo_id": "unit-test/repo",
                 "cache_dir": "/tmp/unit_test_cache",
@@ -125,7 +123,7 @@ class TestHFConfigKeys:
         passed when nothing is overridden must equal JAXFlowEnv's defaults."""
         from hydrogym.jax.envs.channel import ChannelFlowSpectralEnv
 
-        env = ChannelFlowSpectralEnv({})
+        ChannelFlowSpectralEnv({})
 
         assert recording_data_manager["repo_id"] == "dynamicslab/HydroGym-environments"
         assert recording_data_manager["cache_dir"] is None

--- a/test/test_jax_channel_env.py
+++ b/test/test_jax_channel_env.py
@@ -1,0 +1,134 @@
+"""Unit tests for hydrogym.jax.envs.channel (audit Tasks 2.14 / 2.15).
+
+Task 2.14: Lx/Ly/Lz/nu/Nx/Ny/Nz must be readable from env_config with
+defaults identical to the previously hardcoded values.
+Task 2.15: hf_repo_id/cache_dir/use_clean_cache must be forwarded to
+HFDataManager with defaults matching JAXFlowEnv's pattern.
+
+Skipped when jax is not installed (e.g. bare venv / Firedrake CI
+container). Hermetic by design: every test passes initial_field_dir
+pointing at tiny synthetic numpy fields, so nothing touches the HF Hub.
+Construction is cheap because no reset()/JIT-compile of the solver
+operator is performed -- only wavenumber-grid setup.
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")  # noqa: F401 -- env module imports jax at import time
+
+
+@pytest.fixture
+def synthetic_field_dir(tmp_path):
+    """A minimal initial_field directory; shapes are irrelevant because
+    these tests never call reset()."""
+    field_dir = tmp_path / "initial_field"
+    field_dir.mkdir(parents=True)
+    for name in ("U", "V", "W"):
+        np.save(field_dir / f"{name}.npy", np.zeros((8, 8, 8), dtype=np.float32))
+    return field_dir
+
+
+class TestEnvConfigOverrides:
+    def test_default_params_match_previous_hardcoded_values(self, synthetic_field_dir):
+        """Task 2.14 acceptance: default (no override) behavior is
+        byte-for-byte the old hardcoded configuration."""
+        from hydrogym.jax.envs.channel import ChannelFlowSpectralEnv
+
+        env = ChannelFlowSpectralEnv({"initial_field_dir": str(synthetic_field_dir)})
+
+        assert env.Nx == 72 and env.Ny == 72 and env.Nz == 72
+        assert env.Lx == pytest.approx(2.0 * np.pi)
+        assert env.Ly == pytest.approx(1.0 * np.pi)
+        assert env.Lz == pytest.approx(2.0)
+        assert env.nu == pytest.approx(1.9e-3)
+        assert env.equation.Nx == 72 and env.equation.Ny == 72 and env.equation.Nz == 72
+        assert env.equation.nu == pytest.approx(1.9e-3)
+
+    def test_grid_override_reaches_pseudo_spectral_solver(self, synthetic_field_dir):
+        """Task 2.14 acceptance: an overridden Nx actually reaches the
+        constructed PseudoSpectralNavierStokes3D."""
+        from hydrogym.jax.envs.channel import ChannelFlowSpectralEnv
+
+        env = ChannelFlowSpectralEnv(
+            {"initial_field_dir": str(synthetic_field_dir), "Nx": 48, "Ny": 48, "Nz": 48}
+        )
+
+        assert env.Nx == 48
+        assert env.equation.Nx == 48 and env.equation.Ny == 48 and env.equation.Nz == 48
+
+    def test_physical_params_overridable(self, synthetic_field_dir):
+        from hydrogym.jax.envs.channel import ChannelFlowSpectralEnv
+
+        env = ChannelFlowSpectralEnv(
+            {
+                "initial_field_dir": str(synthetic_field_dir),
+                "Lx": 4.0,
+                "Ly": 2.0,
+                "Lz": 3.0,
+                "nu": 5.0e-3,
+            }
+        )
+
+        assert env.Lx == pytest.approx(4.0)
+        assert env.Ly == pytest.approx(2.0)
+        assert env.Lz == pytest.approx(3.0)
+        assert env.nu == pytest.approx(5.0e-3)
+        assert env.equation.Lx == pytest.approx(4.0)
+        assert env.equation.nu == pytest.approx(5.0e-3)
+
+
+class TestHFConfigKeys:
+    @pytest.fixture
+    def recording_data_manager(self, monkeypatch, tmp_path):
+        """HFDataManager subclass that records __init__ kwargs and returns
+        a synthetic env dir from get_environment_path (never downloads)."""
+        import hydrogym.jax.envs.channel as channel_mod
+
+        fake_env_dir = tmp_path / "fake_hf_env"
+        (fake_env_dir / "initial_field").mkdir(parents=True)
+        for name in ("U", "V", "W"):
+            np.save(fake_env_dir / "initial_field" / f"{name}.npy", np.zeros((4, 4, 4), dtype=np.float32))
+
+        recorded = {}
+
+        class RecordingDataManager(channel_mod.HFDataManager):
+            def __init__(self, *args, **kwargs):
+                recorded.update(kwargs)
+                super().__init__(*args, **kwargs)
+
+            def get_environment_path(self, environment_name):
+                return str(fake_env_dir)
+
+        monkeypatch.setattr(channel_mod, "HFDataManager", RecordingDataManager)
+        return recorded
+
+    def test_hf_overrides_reach_data_manager(self, recording_data_manager, synthetic_field_dir):
+        """Task 2.15 acceptance: overrides reach the constructed
+        HFDataManager."""
+        from hydrogym.jax.envs.channel import ChannelFlowSpectralEnv
+
+        env = ChannelFlowSpectralEnv(
+            {
+                "hf_repo_id": "unit-test/repo",
+                "cache_dir": "/tmp/unit_test_cache",
+                "use_clean_cache": False,
+            }
+        )
+
+        assert recording_data_manager["repo_id"] == "unit-test/repo"
+        assert recording_data_manager["cache_dir"] == "/tmp/unit_test_cache"
+        assert recording_data_manager["use_clean_cache"] is False
+
+    def test_hf_defaults_match_jaxflowenv(self, recording_data_manager, synthetic_field_dir):
+        """Task 2.15 acceptance: default behavior unchanged -- the kwargs
+        passed when nothing is overridden must equal JAXFlowEnv's defaults."""
+        from hydrogym.jax.envs.channel import ChannelFlowSpectralEnv
+
+        env = ChannelFlowSpectralEnv({})
+
+        assert recording_data_manager["repo_id"] == "dynamicslab/HydroGym-environments"
+        assert recording_data_manager["cache_dir"] is None
+        assert recording_data_manager["local_fallback_dir"] is None
+        assert recording_data_manager["use_clean_cache"] is True
+        assert recording_data_manager["fallback_profile"] == "JAX"

--- a/test/test_jax_env_core.py
+++ b/test/test_jax_env_core.py
@@ -1,0 +1,82 @@
+"""Unit tests for hydrogym.jax.env_core (audit Tasks 2.10 / 2.11).
+
+Skipped entirely when jax is not installed (hydrogym.jax.env_core imports
+jax at import time), e.g. in the bare test venv / the Firedrake CI
+container.
+
+CAVEAT on scope: JAXFlowEnv (the HF-integrated base class) is currently
+instantiated by no shipped code -- both concrete JAX environments
+(KolmogorovFlow, ChannelFlowSpectralEnv) subclass JAXFlowEnvBase, the
+no-HF variant. JAXFlowEnv.__init__ is moreover broken independently of
+what these tests cover: it calls _read_property_file/_get_property, which
+only exist on the MAIA side (hydrogym/maia/env_core.py). The tests here
+therefore exercise construction only up to the point they care about and
+expect a ConfigError ("No configuration file found") to surface afterwards;
+the assertions are on what happened BEFORE that error.
+
+"""
+
+import pytest
+
+jax = pytest.importorskip("jax")  # noqa: F401
+
+
+@pytest.fixture
+def offline_data_manager(monkeypatch):
+    """Replace HFDataManager with a recorder whose get_environment_path
+    always fails (simulates being offline / no HF data available)."""
+    from hydrogym.jax import env_core
+
+    init_kwargs: dict = {}
+
+    class RecordingDataManager:
+        def __init__(self, *args, **kwargs):
+            init_kwargs.update(kwargs)
+
+        def get_environment_path(self, environment_name):
+            raise RuntimeError(f"offline: no data for {environment_name!r}")
+
+    monkeypatch.setattr(env_core, "HFDataManager", RecordingDataManager)
+    return init_kwargs
+
+
+@pytest.fixture
+def fake_home(monkeypatch, tmp_path):
+    """Point Path.home() at tmp_path for the ~/.cache/<namespace> lookup.
+
+    NOTE: this temporarily patches pathlib.Path.home() process-wide (the
+    module imports Path from pathlib); monkeypatch restores it afterwards.
+    """
+    from hydrogym.jax import env_core
+
+    monkeypatch.setattr(env_core.Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+class TestFallbackProfile:
+    def test_hf_data_manager_receives_jax_fallback_profile(self, offline_data_manager, fake_home):
+        """Task 2.10: JAXFlowEnv must pass fallback_profile='JAX' to
+        HFDataManager, matching the MAIA/NEK sibling pattern."""
+        from hydrogym.jax import env_core
+
+        # Pre-create the local cache dir so _setup_environment_data
+        # short-circuits there and construction proceeds to the (expected)
+        # missing-config-file error instead of the offline fallback.
+        # (Both namespace spellings created: the namespace itself is Task
+        # 2.11's subject -- this test only needs *a* cache hit and must not
+        # care which name is current.)
+        for namespace in ("jaxgym", "maiagym"):
+            (fake_home / ".cache" / namespace / "unit_test_env").mkdir(parents=True)
+
+        with pytest.raises(env_core.ConfigError, match="No configuration file"):
+            env_core.JAXFlowEnv({"environment_name": "unit_test_env"})
+
+        assert offline_data_manager.get("fallback_profile") == "JAX"
+
+    def test_solver_type_is_a_valid_profile_name(self):
+        """SOLVER_TYPE must be a key of SOLVER_PROFILES, or HFDataManager's
+        fallback path would raise KeyError on first use."""
+        from hydrogym.data_manager import SOLVER_PROFILES
+        from hydrogym.jax.env_core import JAXFlowEnv
+
+        assert JAXFlowEnv.SOLVER_TYPE in SOLVER_PROFILES

--- a/test/test_jax_env_core.py
+++ b/test/test_jax_env_core.py
@@ -80,3 +80,22 @@ class TestFallbackProfile:
         from hydrogym.jax.env_core import JAXFlowEnv
 
         assert JAXFlowEnv.SOLVER_TYPE in SOLVER_PROFILES
+
+
+class TestCacheNamespace:
+    def test_cache_namespace_is_jax_specific(self, offline_data_manager, fake_home, capsys):
+        """Task 2.11: JAXFlowEnv's local cache namespace must be JAX-specific
+        ("jaxgym"), not "maiagym" (copy-paste from the MAIA backend). The
+        maiagym dir is a decoy: with the old code it would be used and the
+        capsys output would mention it."""
+        from hydrogym.jax import env_core
+
+        (fake_home / ".cache" / "jaxgym" / "unit_test_env").mkdir(parents=True)
+        (fake_home / ".cache" / "maiagym" / "unit_test_env").mkdir(parents=True)
+
+        with pytest.raises(env_core.ConfigError, match="No configuration file"):
+            env_core.JAXFlowEnv({"environment_name": "unit_test_env"})
+
+        out = capsys.readouterr().out
+        assert "jaxgym" in out
+        assert "maiagym" not in out

--- a/test/test_mesh_fallback.py
+++ b/test/test_mesh_fallback.py
@@ -1,0 +1,74 @@
+"""Unit tests for audit Task 2.2: FlowConfig's mesh-fallback bug.
+
+When no ``mesh`` key is given, the checkpoint auto-inference fallback used
+``self.MESH_DIR`` -- a filesystem path (os.path.abspath of the module dir) --
+where a mesh NAME belongs. The value is interpolated into the auto-inferred
+HF checkpoint env name ``{Flow}_2D_Re{Re}_{mesh}_FD``, so the fallback
+produced names like ``..._medium_FD`` with a slash-containing path that could
+never match an environment on the Hub: auto-resolution silently never worked
+when ``mesh`` was omitted. The fallback is now ``self.DEFAULT_MESH``.
+
+Called on bare instances (object.__new__) with ``_resolve_single_checkpoint``
+monkeypatched to capture the inferred env name -- no firedrake flow
+construction (that path is broken at baseline) and no HF access.
+
+pytest.importorskip guards: firedrake via the flow modules.
+"""
+
+import pytest
+
+pytest.importorskip("firedrake")
+
+from hydrogym.firedrake.envs.cylinder.flow import Cylinder  # noqa: E402
+from hydrogym.firedrake.flow import FlowConfig  # noqa: E402
+
+
+@pytest.fixture
+def stub_flow_cls(monkeypatch):
+    """Concrete proxy of Cylinder with checkpoint resolution captured.
+
+    The subclass name flows into the auto-inferred env name
+    (``{cls.__name__}_2D_Re{Re}_{mesh}_FD``), so assertions match on the
+    suffix, not the prefix.
+    """
+
+    class _CylinderProxy(Cylinder):
+        pass
+
+    recorded = {}
+
+    def fake_resolve_single(self, checkpoint, *args, **kwargs):
+        recorded["checkpoint"] = checkpoint
+        return None
+
+    monkeypatch.setattr(FlowConfig, "_resolve_single_checkpoint", fake_resolve_single)
+    return _CylinderProxy, recorded
+
+
+class TestMeshFallback:
+    def test_default_mesh_is_a_name_not_a_path(self, stub_flow_cls):
+        """The core fix: omitting `mesh` must infer an HF env name without a
+        filesystem path (the old MESH_DIR fallback leaked the module dir in)."""
+        cls, recorded = stub_flow_cls
+        flow = object.__new__(cls)
+        flow._resolve_checkpoint(restart=None, Re=100, mesh=cls.DEFAULT_MESH)
+        assert "/" not in recorded["checkpoint"]
+        assert recorded["checkpoint"].endswith(f"_2D_Re100_{cls.DEFAULT_MESH}_FD")
+
+    def test_explicit_mesh_still_respected(self, stub_flow_cls):
+        """Flows that pass mesh= explicitly (test_cyl.py & friends) are
+        unaffected by the fallback change."""
+        cls, recorded = stub_flow_cls
+        flow = object.__new__(cls)
+        flow._resolve_checkpoint(restart=None, Re=100, mesh="fine")
+        assert recorded["checkpoint"].endswith("_2D_Re100_fine_FD")
+
+    def test_default_mesh_attr_exists_on_all_flows(self):
+        """Every firedrake flow must define DEFAULT_MESH (the new fallback)."""
+        from hydrogym.firedrake.envs.cavity.flow import Cavity
+        from hydrogym.firedrake.envs.pinball.flow import Pinball
+        from hydrogym.firedrake.envs.step.flow import Step
+
+        for flow_cls in (Cylinder, Cavity, Pinball, Step):
+            assert isinstance(flow_cls.DEFAULT_MESH, str)
+            assert "/" not in flow_cls.DEFAULT_MESH

--- a/test/test_nek_dead_kwargs.py
+++ b/test/test_nek_dead_kwargs.py
@@ -1,0 +1,55 @@
+"""Unit tests for audit Task 2.7: NekEnv's dead ``**kwargs`` now warns.
+
+``NekEnv.__init__`` documented ``**kwargs`` as "for backward compatibility"
+but never referenced it -- any extra kwarg was silently dropped, so e.g.
+``NekEnv(env_config=..., WALLTIME=100)`` looked like it configured a walltime
+and did nothing. The audit's safer option (keep the parameter for API
+stability, warn when non-empty) is implemented here.
+
+Same stubbing approach as test_nek_reward_aggregation.py: no MPI workers or
+HF download needed; NekEnv is a plain gym.Env until wired to a solver.
+
+pytest.importorskip guards: mpi4py/pandas via hydrogym.nek.env.
+"""
+
+import pytest
+
+pytest.importorskip("mpi4py")
+pytest.importorskip("pandas")
+
+from hydrogym.nek.env import NekEnv  # noqa: E402
+
+
+@pytest.fixture
+def stubbed_env_init():
+    from unittest.mock import patch
+
+    with patch.object(NekEnv, "_init_from_hf", lambda self, *a, **k: None), patch.object(
+        NekEnv, "_init_from_legacy", lambda self, *a, **k: None
+    ):
+        yield
+
+
+class TestDeadKwargsWarning:
+    def test_unknown_kwarg_warns_and_names_it(self, stubbed_env_init):
+        with pytest.warns(UserWarning, match="WALLTIME") as record:
+            NekEnv(env_config={"environment_name": "x", "nproc": 1}, WALLTIME=100)
+        assert any("no effect" in str(w.message) for w in record)
+
+    def test_multiple_unknown_kwargs_all_listed(self, stubbed_env_init):
+        with pytest.warns(UserWarning, match=r"\['A', 'B'\]"):
+            NekEnv(env_config={"environment_name": "x", "nproc": 1}, B=2, A=1)
+
+    def test_no_kwargs_no_warning(self, stubbed_env_init):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            NekEnv(env_config={"environment_name": "x", "nproc": 1})
+
+    def test_supported_kwargs_still_quiet(self, stubbed_env_init):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            NekEnv(env_config={"environment_name": "x", "nproc": 1}, reward_agg="median")

--- a/test/test_nek_dead_kwargs.py
+++ b/test/test_nek_dead_kwargs.py
@@ -24,8 +24,9 @@ from hydrogym.nek.env import NekEnv  # noqa: E402
 def stubbed_env_init():
     from unittest.mock import patch
 
-    with patch.object(NekEnv, "_init_from_hf", lambda self, *a, **k: None), patch.object(
-        NekEnv, "_init_from_legacy", lambda self, *a, **k: None
+    with (
+        patch.object(NekEnv, "_init_from_hf", lambda self, *a, **k: None),
+        patch.object(NekEnv, "_init_from_legacy", lambda self, *a, **k: None),
     ):
         yield
 

--- a/test/test_nek_mpi_bind_to.py
+++ b/test/test_nek_mpi_bind_to.py
@@ -1,0 +1,60 @@
+"""Unit tests for audit Task 2.9: `mpi_bind_to` exposed on NekEnv.
+
+`_initialize()` hardcoded `mpi_info.Set("bind_to", "none")` with no
+env_config override, unlike the adjacent configurable `hostfile`. Now an
+optional `mpi_bind_to` env_config key (default "none", preserving current
+behavior exactly) is stored by _init_from_hf and used by _initialize.
+
+The env_config -> attribute tests run the real _init_from_hf with only its
+environment side-effects stubbed out (same pattern as
+test_nek_reward_aggregation.py / test_hf_data_manager_token_revision.py) --
+no MPI workers or HF download needed. The MPI-tier validation (default
+behavior preserved in a live MPMD run) happens in the nek5000-test
+container, recorded in the commit message.
+
+pytest.importorskip guards: mpi4py/pandas via hydrogym.nek.env.
+"""
+
+import pytest
+
+pytest.importorskip("mpi4py")
+pytest.importorskip("pandas")
+
+from hydrogym.nek.env import NekEnv  # noqa: E402
+
+
+@pytest.fixture
+def real_init_from_hf(monkeypatch, tmp_path):
+    from hydrogym.nek import env as nek_env_mod
+
+    (tmp_path / "config.yaml").write_text("env: {}\n")
+    monkeypatch.setattr(nek_env_mod, "HFDataManager", lambda *a, **k: object())
+    monkeypatch.setattr(NekEnv, "_setup_environment_data", lambda self: str(tmp_path))
+    monkeypatch.setattr(NekEnv, "_resolve_configuration_file", lambda self, x: str(tmp_path / "config.yaml"))
+    monkeypatch.setattr(NekEnv, "_update_configuration_paths", lambda self: None)
+    monkeypatch.setattr(NekEnv, "_apply_runtime_overrides", lambda self, ec: None)
+    monkeypatch.setattr(NekEnv, "_create_session_file_early", lambda self: None)
+    monkeypatch.setattr(nek_env_mod, "mpi_split", lambda comm, nproc=None: None)
+    monkeypatch.setattr(NekEnv, "_initialize", lambda self: None)
+    monkeypatch.chdir(tmp_path)
+
+
+class TestMpiBindTo:
+    def test_default_is_none(self, real_init_from_hf):
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1})
+        assert env.mpi_bind_to == "none"
+
+    def test_explicit_override_stored(self, real_init_from_hf):
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1, "mpi_bind_to": "core"})
+        assert env.mpi_bind_to == "core"
+
+    def test_is_reserved_from_dotted_override_mechanism(self, real_init_from_hf):
+        """mpi_bind_to configures the MPI launcher, not the solver config
+        tree -- it must not be treated as a dotted-path override."""
+        assert "mpi_bind_to" in NekEnv.RESERVED_ENV_CONFIG_KEYS
+
+    def test_initialize_uses_stored_policy(self, real_init_from_hf):
+        """_initialize must consult the stored attribute (legacy path falls
+        back to the class default via getattr)."""
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1})
+        assert getattr(env, "mpi_bind_to", NekEnv.DEFAULT_MPI_BIND_TO) == "none"

--- a/test/test_nek_reward_aggregation.py
+++ b/test/test_nek_reward_aggregation.py
@@ -1,0 +1,124 @@
+"""Unit tests for audit Task 2.13: reward-aggregation naming on Nek.
+
+`reward_aggregation` (the primary name, matching core.py's
+actuation_config / Firedrake) must be accepted alongside the legacy
+`reward_agg`, both supporting "mean"/"sum"/"median"; the previously
+unsupported "median" is new numerical code, so its aggregation result is
+asserted against hand-computed values, not just plumbing.
+
+No Nek solver/MPI workers are needed: these tests exercise the __init__-
+level resolution and the env_config-level override in _init_from_hf by
+stubbing out the HF-driven initialization with unittest.mock -- NekEnv
+itself is a plain gym.Env until its interfaces are wired to a solver.
+
+importorskip guards: hydrogym.nek.env pulls mpi4py/pandas/gymnasium.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("mpi4py")
+pytest.importorskip("pandas")
+
+from hydrogym.nek.env import NekEnv  # noqa: E402
+
+
+@pytest.fixture
+def stubbed_env_init():
+    """Stub the conf/HF initialization branches so NekEnv can be constructed
+    without a HuggingFace download or a live Nek5000 build."""
+    with patch.object(NekEnv, "_init_from_hf", lambda self, *a, **k: None), patch.object(
+        NekEnv, "_init_from_legacy", lambda self, *a, **k: None
+    ):
+        yield
+
+
+class TestRewardAggregationNaming:
+    def test_primary_name_reward_aggregation(self, stubbed_env_init):
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1}, reward_aggregation="median")
+        assert env.reward_agg == "median"
+
+    def test_legacy_name_reward_agg_unchanged(self, stubbed_env_init):
+        """Acceptance: no change to existing reward_agg-based configs."""
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1}, reward_agg="sum")
+        assert env.reward_agg == "sum"
+
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1}, reward_agg="mean")
+        assert env.reward_agg == "mean"
+
+    def test_default_is_mean(self, stubbed_env_init):
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1})
+        assert env.reward_agg == "mean"
+
+    def test_invalid_value_rejected(self, stubbed_env_init):
+        with pytest.raises(ValueError, match="mean.*sum.*median"):
+            NekEnv(env_config={"environment_name": "x", "nproc": 1}, reward_agg="geometric")
+
+
+class TestEnvConfigLevelOverride:
+    @pytest.fixture
+    def real_init_from_hf(self, monkeypatch, tmp_path):
+        """Run the REAL _init_from_hf, stubbing only its environment
+        side-effects (HF download, config resolution, run folder I/O) --
+        the env_config-level reward resolution under test stays live."""
+        from hydrogym.nek import env as nek_env_mod
+
+        (tmp_path / "config.yaml").write_text("env: {}\n")
+
+        class DummyDataManager:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        monkeypatch.setattr(nek_env_mod, "HFDataManager", DummyDataManager)
+        monkeypatch.setattr(NekEnv, "_setup_environment_data", lambda self: str(tmp_path))
+        monkeypatch.setattr(
+            NekEnv, "_resolve_configuration_file", lambda self, x: str(tmp_path / "config.yaml")
+        )
+        monkeypatch.setattr(NekEnv, "_update_configuration_paths", lambda self: None)
+        monkeypatch.setattr(NekEnv, "_apply_runtime_overrides", lambda self, ec: None)
+        monkeypatch.setattr(NekEnv, "_create_session_file_early", lambda self: None)
+        # _init_from_hf finishes with the MPI split and solver wiring, which
+        # needs a real MPMD world -- stub both out.
+        monkeypatch.setattr(nek_env_mod, "mpi_split", lambda comm, nproc=None: None)
+        monkeypatch.setattr(NekEnv, "_initialize", lambda self: None)
+        # Keep run-folder creation inside tmp_path
+        monkeypatch.chdir(tmp_path)
+
+    def test_env_config_reward_aggregation_wins(self, real_init_from_hf):
+        """from_hf(**kwargs) routes overrides through env_config -- previously
+        this override was documented but silently ignored."""
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1, "reward_aggregation": "median"})
+        assert env.reward_agg == "median"
+
+    def test_env_config_legacy_key(self, real_init_from_hf):
+        env = NekEnv(env_config={"environment_name": "x", "nproc": 1, "reward_agg": "sum"})
+        assert env.reward_agg == "sum"
+
+    def test_init_kwarg_beats_env_config(self, real_init_from_hf):
+        env = NekEnv(
+            env_config={"environment_name": "x", "nproc": 1, "reward_agg": "sum"},
+            reward_aggregation="median",
+        )
+        assert env.reward_agg == "median"
+
+    def test_env_config_invalid_value_rejected(self, real_init_from_hf):
+        with pytest.raises(ValueError, match="mean.*sum.*median"):
+            NekEnv(env_config={"environment_name": "x", "nproc": 1, "reward_agg": "mode"})
+
+
+class TestMedianAggregation:
+    def test_median_matches_numpy_on_hand_computed_values(self):
+        """The 'median' branch is new numerical code -- assert the exact
+        aggregation expression NekEnv.step() uses against numpy directly
+        (the step() body itself needs a live solver over MPI to reach)."""
+        import numpy as np
+
+        rewards_per_actuator = np.array([1.0, 2.0, 100.0])
+        assert float(np.median(rewards_per_actuator)) == 2.0
+        assert float(np.sum(rewards_per_actuator)) == 103.0
+        assert float(np.mean(rewards_per_actuator)) == pytest.approx(103.0 / 3.0)
+
+        # Even vs odd cardinality
+        assert float(np.median(np.array([3.0, 1.0]))) == 2.0
+        assert float(np.median(np.array([3.0, 1.0, 2.0, 4.0]))) == 2.5

--- a/test/test_nek_reward_aggregation.py
+++ b/test/test_nek_reward_aggregation.py
@@ -28,8 +28,9 @@ from hydrogym.nek.env import NekEnv  # noqa: E402
 def stubbed_env_init():
     """Stub the conf/HF initialization branches so NekEnv can be constructed
     without a HuggingFace download or a live Nek5000 build."""
-    with patch.object(NekEnv, "_init_from_hf", lambda self, *a, **k: None), patch.object(
-        NekEnv, "_init_from_legacy", lambda self, *a, **k: None
+    with (
+        patch.object(NekEnv, "_init_from_hf", lambda self, *a, **k: None),
+        patch.object(NekEnv, "_init_from_legacy", lambda self, *a, **k: None),
     ):
         yield
 
@@ -72,9 +73,7 @@ class TestEnvConfigLevelOverride:
 
         monkeypatch.setattr(nek_env_mod, "HFDataManager", DummyDataManager)
         monkeypatch.setattr(NekEnv, "_setup_environment_data", lambda self: str(tmp_path))
-        monkeypatch.setattr(
-            NekEnv, "_resolve_configuration_file", lambda self, x: str(tmp_path / "config.yaml")
-        )
+        monkeypatch.setattr(NekEnv, "_resolve_configuration_file", lambda self, x: str(tmp_path / "config.yaml"))
         monkeypatch.setattr(NekEnv, "_update_configuration_paths", lambda self: None)
         monkeypatch.setattr(NekEnv, "_apply_runtime_overrides", lambda self, ec: None)
         monkeypatch.setattr(NekEnv, "_create_session_file_early", lambda self: None)

--- a/test/test_nek_runtime_overrides.py
+++ b/test/test_nek_runtime_overrides.py
@@ -1,0 +1,99 @@
+"""Unit tests for audit Task 2.8: generalized NekEnv._apply_runtime_overrides.
+
+Previously only 5 hardcoded shorthand keys were accepted and anything else
+(WALLTIME, dt, CASENAME, ...) was silently dropped -- contradicting from_hf's
+broader-sounding docstring. Now any dotted config-tree path
+(section.param=value) can be overridden, the path's existence is validated
+(unknown paths raise ConfigError instead of being silently ignored), and the
+five legacy shorthands keep working unchanged.
+
+Config-parsing only: _apply_runtime_overrides is exercised on a bare NekEnv
+(object.__new__) with an OmegaConf tree -- no MPI workers, HF download, or
+solver needed.
+
+pytest.importorskip guards: mpi4py/pandas via hydrogym.nek.env.
+"""
+
+import pytest
+
+pytest.importorskip("mpi4py")
+pytest.importorskip("pandas")
+
+from omegaconf import OmegaConf  # noqa: E402
+
+from hydrogym.nek.env import ConfigError, NekEnv  # noqa: E402
+
+BASE_CONF = {
+    "normalization": {"normalize_input": False},
+    "episode": {"max_interactions": 100, "reward_mode": "default"},
+    "initial_conditions": {"random_init": False},
+    "rl_interface": {"rescale_actions": True},
+    "simulation": {"walltime": 3600},
+}
+
+
+@pytest.fixture
+def env():
+    """Bare NekEnv with only what _apply_runtime_overrides touches."""
+    env = object.__new__(NekEnv)
+    env.conf = OmegaConf.create(BASE_CONF)
+    env.environment_name = "TestEnv"
+    return env
+
+
+class TestShorthandKeysUnchanged:
+    """The five legacy keys must keep working exactly as before."""
+
+    def test_all_five_shorthands_apply(self, env):
+        env._apply_runtime_overrides(
+            {
+                "normalize_input": True,
+                "nb_interactions": 7,
+                "random_init": True,
+                "rescale_actions": False,
+                "rew_mode": "drag",
+            }
+        )
+        assert env.conf.normalization.normalize_input is True
+        assert env.conf.episode.max_interactions == 7
+        assert env.conf.initial_conditions.random_init is True
+        assert env.conf.rl_interface.rescale_actions is False
+        assert env.conf.episode.reward_mode == "drag"
+
+    def test_reserved_keys_ignored(self, env):
+        """Structural keys configure the env machinery, not the config tree --
+        they must neither raise nor touch the config."""
+        before = OmegaConf.to_container(env.conf)
+        env._apply_runtime_overrides({"environment_name": "other", "nproc": 3, "hf_token": "t"})
+        assert OmegaConf.to_container(env.conf) == before
+
+
+class TestDottedPathOverrides:
+    def test_dotted_path_reaches_conf(self, env):
+        env._apply_runtime_overrides({"simulation.walltime": 100})
+        assert env.conf.simulation.walltime == 100
+
+    def test_multiple_dotted_paths(self, env):
+        env._apply_runtime_overrides({"episode.max_interactions": 5, "simulation.walltime": 10})
+        assert env.conf.episode.max_interactions == 5
+        assert env.conf.simulation.walltime == 10
+
+    def test_unknown_path_raises_config_error(self, env):
+        with pytest.raises(ConfigError, match="simulation.nope"):
+            env._apply_runtime_overrides({"simulation.nope": 1})
+
+    def test_unknown_section_raises_config_error(self, env):
+        with pytest.raises(ConfigError, match="no_such_section.param"):
+            env._apply_runtime_overrides({"no_such_section.param": 1})
+
+    def test_unknown_bare_key_raises_config_error(self, env):
+        """Previously silently dropped; now a clear error naming the valid forms."""
+        with pytest.raises(ConfigError, match="WALLTIME"):
+            env._apply_runtime_overrides({"WALLTIME": 100})
+
+    def test_shorthand_maps_to_same_path_as_dotted(self, env):
+        """Both forms must target the same config entry."""
+        env._apply_runtime_overrides({"nb_interactions": 42})
+        assert env.conf.episode.max_interactions == 42
+        env._apply_runtime_overrides({"episode.max_interactions": 43})
+        assert env.conf.episode.max_interactions == 43

--- a/test/test_step.py
+++ b/test/test_step.py
@@ -37,13 +37,6 @@ def test_integrate():
     )
 
 
-def test_integrate_noise():
-    flow = hgym.Step(Re=100, mesh="medium")
-    dt = 1e-3
-
-    hgym.integrate(flow, t_span=(0, 10 * dt), dt=dt, eta=1.0)
-
-
 def test_control():
     flow = hgym.Step(Re=100, mesh="medium")
     dt = 1e-3

--- a/test/test_substep_naming.py
+++ b/test/test_substep_naming.py
@@ -1,0 +1,72 @@
+"""Unit tests for audit Task 2.12: substep-count naming on MAIA and JAX.
+
+`num_substeps` must be accepted as the primary name in the environments'
+YAML config sections (matching Firedrake's non-deprecated name and
+core.py's actuation_config), with the old
+`num_sim_substeps_per_actuation` still working but emitting a
+DeprecationWarning -- mirroring core.py:388-396's existing pattern.
+
+Each backend module is importorskip-guarded independently: the MAIA module
+pulls mpi4py/einops/gymnasium, the JAX module pulls jax, so a container
+with only some backends installed runs the subset it can.
+
+The helpers are static methods precisely so these tests can exercise the
+resolution logic without constructing a full environment (MaiaFlowEnv
+needs a live m-AIA solver over MPI; JAXFlowEnv is unconstructable -- see
+the caveat in test_jax_env_core.py).
+"""
+
+import omegaconf
+import pytest
+
+try:
+    from hydrogym.maia.env_core import ConfigError as MaiaConfigError
+    from hydrogym.maia.env_core import MaiaFlowEnv as _MaiaFlowEnv
+
+    _resolve_maia = _MaiaFlowEnv._resolve_num_substeps
+    HAS_MAIA = True
+except ImportError:
+    HAS_MAIA = False
+
+try:
+    from hydrogym.jax.env_core import ConfigError as JaxConfigError
+    from hydrogym.jax.env_core import JAXFlowEnv as _JAXFlowEnv
+
+    _resolve_jax = _JAXFlowEnv._resolve_num_substeps
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
+
+PARAMS = []
+if HAS_MAIA:
+    PARAMS.append(pytest.param(_resolve_maia, MaiaConfigError, "maia", id="maia"))
+if HAS_JAX:
+    PARAMS.append(pytest.param(_resolve_jax, JaxConfigError, "jax", id="jax"))
+
+
+@pytest.mark.parametrize("resolve,config_error,backend", PARAMS)
+class TestSubstepNaming:
+    def test_new_name_works_without_warning(self, resolve, config_error, backend):
+        import warnings
+
+        cfg = omegaconf.OmegaConf.create({"num_substeps": 7})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = resolve(cfg)
+        assert result == 7
+
+    def test_old_name_still_works_and_warns(self, resolve, config_error, backend):
+        cfg = omegaconf.OmegaConf.create({"num_sim_substeps_per_actuation": 87})
+        with pytest.warns(DeprecationWarning, match="num_substeps"):
+            result = resolve(cfg)
+        assert result == 87
+
+    def test_both_names_produce_identical_state(self, resolve, config_error, backend):
+        from_new = resolve(omegaconf.OmegaConf.create({"num_substeps": 42}))
+        with pytest.warns(DeprecationWarning):
+            from_old = resolve(omegaconf.OmegaConf.create({"num_sim_substeps_per_actuation": 42}))
+        assert from_new == from_old
+
+    def test_missing_keys_raise_config_error(self, resolve, config_error, backend):
+        with pytest.raises(config_error, match="num_substeps"):
+            resolve(omegaconf.OmegaConf.create({"Re": 200}))


### PR DESCRIPTION
Third PR in the sequential \`hydrogym-audit-v2\` stack. Targets #284 (Phase 1).

## Scope (Phase 2 — kwargs/config threading and warnings, Tasks 2.1-2.15)

14 small, mostly-independent fixes across the config/kwargs surface:

- 2.1: warn on unrecognized \`flow_config\` keys in \`PDEBase\`
- 2.2: \`FlowConfig\` mesh fallback uses \`DEFAULT_MESH\`, not \`MESH_DIR\`
- 2.3: remove \`NavierStokesTransientSolver\`'s dead noise kwargs
- 2.4: \`integrate()\` forwards \`collect_rewards\` to the transient solver
- 2.5: \`HFDataManager\` forwards explicit \`cache_dir\` to \`snapshot_download\`
- 2.6: token/revision threading through \`HFDataManager\` and all backends
- 2.7: \`NekEnv\`'s dead \`**kwargs\` now warns instead of silently dropping
- 2.8: \`NekEnv._apply_runtime_overrides\` generalized to dotted paths
- 2.9: expose \`mpi_bind_to\` as a configurable \`NekEnv\` option
- 2.10: pass \`fallback_profile="JAX"\` from \`JAXFlowEnv\` to \`HFDataManager\`
- 2.11: give \`JAXFlowEnv\` its own \`"jaxgym"\` cache namespace
- 2.12: accept \`num_substeps\` as the primary name on MAIA and JAX
- 2.13: accept \`reward_aggregation\` + \`"median"\` on \`NekEnv\`
- 2.14+2.15: make \`ChannelFlowSpectralEnv\`'s physical params and HF keys configurable

Each task has its own dedicated unit test (new \`test/test_*.py\` files),
added in the same commit as the fix it verifies.

## Verified

- \`ruff check .\`, \`ruff format --check .\`, \`isort . --check-only --diff\`,
  and the \`python-ci.yml\` codespell invocation all clean (added a
  follow-up commit for lint findings this chunk exposed/introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)