### PR TITLE
Audit Phase 3: HFEnvConfigMixin / ExternalProcessEnvMixin refactor

### DIFF
--- a/hydrogym/core_external.py
+++ b/hydrogym/core_external.py
@@ -1,0 +1,176 @@
+"""Shared MPMD communicator setup for external-process backends (audit Task 3.5).
+
+The Nek and MAIA backends both talk to their CFD solver as a separate MPI
+application launched in the same MPMD world (``mpirun -n 1 python ... :
+-n N ./solver``). Each previously owned a private copy of the world-split
+logic:
+
+  - ``hydrogym.nek.env.mpi_split`` -- rank-color split (rank 0 = controller,
+    ranks 1+ = workers) followed by ``Create_intercomm``; validates the
+    world size against the expected worker count.
+  - ``hydrogym.maia.mpmd_interface.MaiaInterface.init_comm`` -- APPNUM-based
+    split (true MPMD, any controller rank count), with group-translation +
+    Allreduce discovery of the remote application's root rank.
+
+The two are genuinely different split strategies (not copies), so this
+module hosts each verbatim as a named function and adds
+`ExternalProcessEnvMixin` as the common extension point carrying the
+protocol knobs (controller rank, intercomm tag, log prefix). Per-solver
+tag-protocol code (the actual command/data messages) stays untouched in
+each backend.
+
+Callers:
+  - NekEnv (mixin ``_split_mpmd_comm``); ``hydrogym.nek.env.mpi_split`` is
+    re-exported from here so ``hydrogym.nek.mpi_split`` and the
+    ``monkeypatch.setattr(nek_env_mod, "mpi_split", ...)`` test idiom keep
+    working.
+  - ``MaiaInterface.init_comm`` delegates its communicator setup to
+    ``split_comm_by_appnum`` and assigns the results.
+"""
+
+from typing import Optional, Tuple
+
+import numpy as np
+from mpi4py import MPI
+
+
+def mpi_split(
+    comm_world: MPI.Comm,
+    nproc: Optional[int] = None,
+    controller_rank: int = 0,
+    intercomm_tag: int = 99,
+    log_prefix: str = "[MPI_SPLIT] ",
+) -> MPI.Comm:
+    """Split the MPMD world into a controller/worker inter-communicator
+    (Nek protocol: rank 0 is the controller, ranks 1+ are the workers).
+
+    Args:
+      comm_world: MPI communicator (typically MPI.COMM_WORLD)
+      nproc: Expected number of solver workers (for validation)
+      controller_rank: World rank of the controller (default 0)
+      intercomm_tag: MPI tag for the inter-communicator handshake
+      log_prefix: Prefix for the split log lines
+
+    Returns:
+      Inter-communicator between controller and workers
+    """
+    mpi_rank = comm_world.Get_rank()
+    mpi_size = comm_world.Get_size()
+
+    if mpi_size < 2:
+        raise RuntimeError(
+            "MPI world size must be >= 2 to create the Nek inter-communicator. "
+            "Launch with MPMD, e.g. `mpirun -n 1 python ... : -n N ./nek5000`, "
+            "so rank 0 can connect to the Nek worker ranks."
+        )
+
+    # Validate MPI size matches nproc
+    if nproc is not None:
+        expected_size = 1 + nproc  # 1 controller + N workers
+        if mpi_size != expected_size:
+            raise RuntimeError(
+                f"MPI world size mismatch: expected {expected_size} "
+                f"(1 controller + {nproc} workers), got {mpi_size}. "
+                f"Launch with: mpirun -n 1 python ... : -n {nproc} ./nek5000"
+            )
+
+    color = 0 if mpi_rank == controller_rank else 1
+
+    local_comm = comm_world.Split(color, mpi_rank)
+    print(
+        f"{log_prefix}World rank {mpi_rank}, color {color}, "
+        f"local_comm size: {local_comm.Get_size()}, "
+        f"local rank: {local_comm.Get_rank()}",
+        flush=True,
+    )
+
+    # NOTE: the original NekEnv copy hardcoded remote_leader=1 on BOTH
+    # sides. That is correct only for the controller side (whose remote
+    # leader is world rank 1, the worker app's leader -- in production the
+    # workers are the Nek5000 Fortran binary, so the Python color-1 branch
+    # never runs there). A Python worker passing 1 would contact itself and
+    # leave the controller hanging in Create_intercomm forever -- exactly
+    # what test/mpmd_smoke_split.py exposed. 1 - color selects the other
+    # app's leader on both sides and is identical on the production
+    # controller path.
+    sub_comm = local_comm.Create_intercomm(
+        local_leader=0, peer_comm=MPI.COMM_WORLD, remote_leader=1 - color, tag=intercomm_tag
+    )
+    print(
+        f"{log_prefix}Inter-comm created: local_size={sub_comm.Get_size()}, "
+        f"remote_size={sub_comm.Get_remote_size()}",
+        flush=True,
+    )
+    return sub_comm
+
+
+def split_comm_by_appnum(
+    comm_world: MPI.Comm,
+) -> Tuple[int, MPI.Comm, int, int, MPI.Group, int, int]:
+    """Split the MPMD world by application number (MAIA protocol: works for
+    any controller rank count; the remote application's root is discovered
+    via group translation + Allreduce).
+
+    Args:
+      comm_world: MPI communicator, typically MPI.COMM_WORLD.
+
+    Returns:
+      Tuple of (appnum, appComm, appRank, appNoRanks, appGroup,
+      appRootInWorld, remoteRoot) for MaiaInterface to assign.
+    """
+    appnum = comm_world.Get_attr(MPI.APPNUM)
+    rank_world = comm_world.Get_rank()
+    app_comm = comm_world.Split(appnum, rank_world)
+    app_rank = app_comm.Get_rank()
+    app_no_ranks = app_comm.Get_size()
+    app_group = app_comm.Get_group()
+    app_root = 0
+
+    # Get root of other application.
+    # NOTE: the original MaiaInterface copy translated in the wrong
+    # direction (world group -> app group), which yields MPI_UNDEFINED (-1)
+    # for every app except app 0 -- the value only ever came out right
+    # because the Python controller is always app 0, so world rank 0 ==
+    # app rank 0 and both directions coincide. The intended semantics ("app
+    # root's rank in WORLD") needs the app group -> world group direction
+    # used here, which test/mpmd_smoke_split.py proved necessary for a
+    # Python app 1 (its Allreduce slot stayed -1 otherwise). Identical
+    # result on the production path (Python = app 0).
+    group_world = comm_world.Get_group()
+    app_root_in_world = app_group.Translate_ranks([app_root], group_world)[0]
+
+    no_app = 2
+    buff_send = np.zeros(no_app, dtype="i")
+    app_roots_in_world = np.empty_like(buff_send)
+    buff_send.fill(-1)
+    buff_send[appnum] = app_root_in_world
+    comm_world.Allreduce(buff_send, app_roots_in_world, op=MPI.MAX)
+    remote_root = app_roots_in_world[1 - appnum]
+
+    return appnum, app_comm, app_rank, app_no_ranks, app_group, app_root_in_world, remote_root
+
+
+class ExternalProcessEnvMixin:
+    """Mixin for environments whose CFD solver runs as a separate MPI
+    application in the same MPMD world.
+
+    Class attributes (override per backend):
+      CONTROLLER_RANK: world rank of the RL controller app (default 0)
+      INTERCOMM_TAG: tag for the inter-communicator handshake (default 99)
+      MPI_SPLIT_LOG_PREFIX: prefix for split log lines (default "[MPI_SPLIT] ")
+    """
+
+    CONTROLLER_RANK: int = 0
+    INTERCOMM_TAG: int = 99
+    MPI_SPLIT_LOG_PREFIX: str = "[MPI_SPLIT] "
+
+    def _split_mpmd_comm(self, comm_world: MPI.Comm, nproc: Optional[int] = None) -> MPI.Comm:
+        """Split the world and return the controller<->solver
+        inter-communicator (rank-color strategy; see `mpi_split`)."""
+        return mpi_split(
+            comm_world,
+            nproc=nproc,
+            controller_rank=self.CONTROLLER_RANK,
+            intercomm_tag=self.INTERCOMM_TAG,
+            log_prefix=self.MPI_SPLIT_LOG_PREFIX,
+        )

--- a/hydrogym/core_external.py
+++ b/hydrogym/core_external.py
@@ -97,8 +97,7 @@ def mpi_split(
         local_leader=0, peer_comm=MPI.COMM_WORLD, remote_leader=1 - color, tag=intercomm_tag
     )
     print(
-        f"{log_prefix}Inter-comm created: local_size={sub_comm.Get_size()}, "
-        f"remote_size={sub_comm.Get_remote_size()}",
+        f"{log_prefix}Inter-comm created: local_size={sub_comm.Get_size()}, remote_size={sub_comm.Get_remote_size()}",
         flush=True,
     )
     return sub_comm

--- a/hydrogym/hf_env_mixin.py
+++ b/hydrogym/hf_env_mixin.py
@@ -46,6 +46,11 @@ class HFEnvConfigMixin:
     # (offline / legacy data). Must be a key of data_manager.SOLVER_PROFILES.
     SOLVER_TYPE: Optional[str] = None
 
+    # Optional prefix for the resolution-method log lines (e.g. "[NEK] " on
+    # the Nek backend, which tags all its prints that way). Empty for the
+    # backends whose copies printed bare messages.
+    LOG_PREFIX: str = ""
+
     HF_CACHE_NAMESPACE: str = None
 
     def _make_data_manager(
@@ -82,13 +87,13 @@ class HFEnvConfigMixin:
         # Check cache directory first
         cache_dir = Path.home() / ".cache" / self.HF_CACHE_NAMESPACE / self.environment_name
         if cache_dir.exists() and cache_dir.is_dir():
-            print(f"Using cached environment data from: {cache_dir}")
+            print(f"{self.LOG_PREFIX}Using cached environment data from: {cache_dir}")
             return str(cache_dir)
 
         # Fall back to data_manager if cache doesn't exist
         try:
             env_path = self.data_manager.get_environment_path(self.environment_name)
-            print(f"Using environment data from: {env_path}")
+            print(f"{self.LOG_PREFIX}Using environment data from: {env_path}")
             return env_path
         except Exception as e:
             raise ConfigError(f"Failed to setup environment data for {self.environment_name}: {e}")

--- a/hydrogym/hf_env_mixin.py
+++ b/hydrogym/hf_env_mixin.py
@@ -1,0 +1,191 @@
+"""Shared Hugging-Face environment-config resolution logic (audit Task 3.1).
+
+Four backends (jaxfluids, jax, maia, nek) carried near-identical private
+copies of the same three methods:
+
+    _setup_environment_data()      -- local ~/.cache/<namespace>/<env> lookup,
+                                      falling back to HFDataManager
+    _resolve_configuration_file()  -- None / abs path / ./relative / filename
+    _find_configuration_file()     -- auto-detect config.yaml in the env dir
+
+with only the cache-namespace string differing per backend. This module
+extracts them into `HFEnvConfigMixin`, parameterized by the class-level
+`HF_CACHE_NAMESPACE` (and, for data-manager construction, `SOLVER_TYPE`).
+Backends migrate to the mixin one at a time to keep blast radius small;
+the method bodies here are copied verbatim from the JAX-Fluids backend,
+which is migrated first (Task 3.1).
+"""
+
+import glob
+import os
+from pathlib import Path
+from typing import Optional
+
+from hydrogym.data_manager import HFDataManager
+
+
+class ConfigError(Exception):
+    """Exception raised for configuration-related errors."""
+
+
+class HFEnvConfigMixin:
+    """Environment-data download / config-file resolution shared by the
+    HF-backed backends.
+
+    Requires on the consuming class:
+      - ``HF_CACHE_NAMESPACE``: per-backend cache directory name under
+        ``~/.cache`` (e.g. "jaxfluidsgym", "jaxgym", "maiagym", "nekgym").
+      - ``self.environment_name``, ``self.env_data_path``, and a
+        ``self.data_manager`` (HFDataManager) instance before the
+        resolution methods are called (i.e. ``_init_from_hf`` order:
+        data_manager -> environment_name -> _setup_environment_data ->
+        _resolve_configuration_file).
+    """
+
+    # Solver profile used by HFDataManager when no sentinel file is found
+    # (offline / legacy data). Must be a key of data_manager.SOLVER_PROFILES.
+    SOLVER_TYPE: Optional[str] = None
+
+    HF_CACHE_NAMESPACE: str = None
+
+    def _make_data_manager(
+        self,
+        hf_repo_id: str,
+        local_fallback_dir: Optional[str],
+        use_clean_cache: bool,
+        token: Optional[str] = None,
+        revision: Optional[str] = None,
+    ) -> HFDataManager:
+        """Build the backend's HFDataManager from the standard env_config keys."""
+        return HFDataManager(
+            repo_id=hf_repo_id,
+            local_fallback_dir=local_fallback_dir,
+            use_clean_cache=use_clean_cache,
+            fallback_profile=self.SOLVER_TYPE,
+            token=token,
+            revision=revision,
+        )
+
+    def _setup_environment_data(self) -> str:
+        """
+        Download and setup environment data from HF Hub.
+
+        First checks ~/.cache/<HF_CACHE_NAMESPACE>/ for local data, otherwise
+        falls back to data_manager.
+
+        Returns:
+            Path to the local environment data directory.
+
+        Raises:
+            ConfigError: If environment data cannot be retrieved.
+        """
+        # Check cache directory first
+        cache_dir = Path.home() / ".cache" / self.HF_CACHE_NAMESPACE / self.environment_name
+        if cache_dir.exists() and cache_dir.is_dir():
+            print(f"Using cached environment data from: {cache_dir}")
+            return str(cache_dir)
+
+        # Fall back to data_manager if cache doesn't exist
+        try:
+            env_path = self.data_manager.get_environment_path(self.environment_name)
+            print(f"Using environment data from: {env_path}")
+            return env_path
+        except Exception as e:
+            raise ConfigError(f"Failed to setup environment data for {self.environment_name}: {e}")
+
+    def _resolve_configuration_file(self, config_file_input: Optional[str]) -> Optional[str]:
+        """
+        Resolve configuration file path from various input formats.
+
+        Args:
+            config_file_input: Can be:
+                - None: Auto-detect in HF environment
+                - Absolute path: Use directly
+                - Relative path starting with . or /: Use as-is
+                - Just filename: Look in HF environment directory
+
+        Returns:
+            Absolute path to configuration file, or None if not found.
+
+        Raises:
+            ConfigError: If specified configuration file is not found.
+        """
+        # Case 1: No config file specified - try to find one
+        if config_file_input is None:
+            print("No config file specified, searching in environment directory...")
+            return self._find_configuration_file()
+
+        # Case 2: Absolute path provided
+        if os.path.isabs(config_file_input):
+            if os.path.exists(config_file_input):
+                print(f"Using absolute path config file: {config_file_input}")
+                return config_file_input
+            else:
+                raise ConfigError(f"Configuration file not found: {config_file_input}")
+
+        # Case 3: Relative path from current directory (starts with ./ or ../)
+        if config_file_input.startswith("./") or config_file_input.startswith("../"):
+            abs_path = os.path.abspath(config_file_input)
+            if os.path.exists(abs_path):
+                print(f"Using config file from current directory: {abs_path}")
+                return abs_path
+            else:
+                raise ConfigError(f"Configuration file not found: {abs_path}")
+
+        # Case 4: Just a filename - look in multiple places
+        # First check current directory
+        if os.path.exists(config_file_input):
+            abs_path = os.path.abspath(config_file_input)
+            print(f"Using config file from current directory: {abs_path}")
+            return abs_path
+
+        # Then check HF environment directory
+        env_config_path = os.path.join(self.env_data_path, config_file_input)
+        if os.path.exists(env_config_path):
+            print(f"Using config file from environment: {env_config_path}")
+            return env_config_path
+
+        raise ConfigError(
+            f"Configuration file '{config_file_input}' not found in:\n"
+            f"  - Current directory: {os.getcwd()}\n"
+            f"  - Environment directory: {self.env_data_path}"
+        )
+
+    def _find_configuration_file(self) -> Optional[str]:
+        """
+        Auto-detect configuration file in the environment data directory.
+
+        Returns:
+            Path to configuration file, or None if not found.
+        """
+        # Look for specific configuration file names (most specific first)
+        config_names = [
+            "config.yaml",
+            "environment_config.yaml",
+            "env_config.yaml",
+            "environment.yaml",
+            f"{self.environment_name}.yaml",
+        ]
+
+        # Check exact names first
+        for name in config_names:
+            file_path = os.path.join(self.env_data_path, name)
+            if os.path.exists(file_path):
+                print(f"Auto-detected configuration file: {name}")
+                return file_path
+
+        # Then try patterns (but be specific - avoid catching property files)
+        config_patterns = ["config_*.yaml", "config_*.yml"]
+
+        for pattern in config_patterns:
+            matches = glob.glob(os.path.join(self.env_data_path, pattern))
+            if matches:
+                print(f"Auto-detected configuration file: {os.path.basename(matches[0])}")
+                return matches[0]
+
+        # Not found
+        print(f"WARNING: No configuration file auto-detected in {self.env_data_path}")
+        if os.path.exists(self.env_data_path):
+            print(f"Available files: {os.listdir(self.env_data_path)}")
+
+        return None

--- a/hydrogym/jax/env_core.py
+++ b/hydrogym/jax/env_core.py
@@ -7,10 +7,8 @@ with Hugging Face Hub integration for configuration management.
 
 """
 
-import glob
 import os
 from functools import partial
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple, TypeVar, Union
 
 import chex
@@ -24,12 +22,7 @@ from flax import struct
 from gymnax.environments import environment, spaces
 
 from hydrogym.data_manager import SOLVER_PROFILES, HFDataManager  # noqa: F401
-
-
-class ConfigError(Exception):
-    """Exception raised for configuration-related errors."""
-
-    pass
+from hydrogym.hf_env_mixin import ConfigError, HFEnvConfigMixin
 
 
 class EnvParams(environment.EnvParams):
@@ -39,7 +32,7 @@ class EnvParams(environment.EnvParams):
 EnvState = TypeVar("EnvState", bound=environment.EnvState)
 
 
-class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
+class JAXFlowEnv(HFEnvConfigMixin, environment.Environment[EnvState, EnvParams]):
     """
     Base JAXFlowEnv with Hugging Face Hub integration for configuration management.
 
@@ -60,6 +53,9 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
     # Solver profile used by HFDataManager when no sentinel file is found
     # (offline / legacy data). Must be a key of data_manager.SOLVER_PROFILES.
     SOLVER_TYPE: str = "JAX"
+
+    # Per-backend cache directory under ~/.cache
+    HF_CACHE_NAMESPACE = "jaxgym"
 
     @staticmethod
     def _resolve_num_substeps(cfg_section) -> int:
@@ -174,129 +170,6 @@ class JAXFlowEnv(environment.Environment[EnvState, EnvParams]):
         self.nDim = self._get_property(self.runtime_property_file_data, "nDim")
         self.zLength = self._get_property(self.runtime_property_file_data, "zLength") if self.nDim == 3 else self.dX
         self.Nz = self._get_property(self.runtime_property_file_data, "Nz") if self.nDim == 3 else self.dX
-
-    def _setup_environment_data(self) -> str:
-        """
-        Download and setup environment data from HF Hub.
-
-        First checks ~/.cache/jaxgym/ for local data, otherwise falls back to data_manager.
-
-        Returns:
-            Path to the local environment data directory.
-
-        Raises:
-            ConfigError: If environment data cannot be retrieved.
-        """
-        # Check cache directory first
-        cache_dir = Path.home() / ".cache" / "jaxgym" / self.environment_name
-        if cache_dir.exists() and cache_dir.is_dir():
-            print(f"Using cached environment data from: {cache_dir}")
-            return str(cache_dir)
-
-        # Fall back to data_manager if cache doesn't exist
-        try:
-            env_path = self.data_manager.get_environment_path(self.environment_name)
-            print(f"Using environment data from: {env_path}")
-            return env_path
-        except Exception as e:
-            raise ConfigError(f"Failed to setup environment data for {self.environment_name}: {e}")
-
-    def _resolve_configuration_file(self, config_file_input: Optional[str]) -> Optional[str]:
-        """
-        Resolve configuration file path from various input formats.
-
-        Args:
-            config_file_input: Can be:
-                - None: Auto-detect in HF environment
-                - Absolute path: Use directly
-                - Relative path starting with . or /: Use as-is
-                - Just filename: Look in HF environment directory
-
-        Returns:
-            Absolute path to configuration file, or None if not found.
-
-        Raises:
-            ConfigError: If specified configuration file is not found.
-        """
-        # Case 1: No config file specified - try to find one
-        if config_file_input is None:
-            print("No config file specified, searching in environment directory...")
-            return self._find_configuration_file()
-
-        # Case 2: Absolute path provided
-        if os.path.isabs(config_file_input):
-            if os.path.exists(config_file_input):
-                print(f"Using absolute path config file: {config_file_input}")
-                return config_file_input
-            else:
-                raise ConfigError(f"Configuration file not found: {config_file_input}")
-
-        # Case 3: Relative path from current directory (starts with ./ or ../)
-        if config_file_input.startswith("./") or config_file_input.startswith("../"):
-            abs_path = os.path.abspath(config_file_input)
-            if os.path.exists(abs_path):
-                print(f"Using config file from current directory: {abs_path}")
-                return abs_path
-            else:
-                raise ConfigError(f"Configuration file not found: {abs_path}")
-
-        # Case 4: Just a filename - look in multiple places
-        # First check current directory
-        if os.path.exists(config_file_input):
-            abs_path = os.path.abspath(config_file_input)
-            print(f"Using config file from current directory: {abs_path}")
-            return abs_path
-
-        # Then check HF environment directory
-        env_config_path = os.path.join(self.env_data_path, config_file_input)
-        if os.path.exists(env_config_path):
-            print(f"Using config file from environment: {env_config_path}")
-            return env_config_path
-
-        raise ConfigError(
-            f"Configuration file '{config_file_input}' not found in:\n"
-            f"  - Current directory: {os.getcwd()}\n"
-            f"  - Environment directory: {self.env_data_path}"
-        )
-
-    def _find_configuration_file(self) -> Optional[str]:
-        """
-        Auto-detect configuration file in the environment data directory.
-
-        Returns:
-            Path to configuration file, or None if not found.
-        """
-        # Look for specific configuration file names (most specific first)
-        config_names = [
-            "config.yaml",
-            "environment_config.yaml",
-            "env_config.yaml",
-            "environment.yaml",
-            f"{self.environment_name}.yaml",
-        ]
-
-        # Check exact names first
-        for name in config_names:
-            file_path = os.path.join(self.env_data_path, name)
-            if os.path.exists(file_path):
-                print(f"Auto-detected configuration file: {name}")
-                return file_path
-
-        # Then try patterns (but be specific - avoid catching property files)
-        config_patterns = ["config_*.yaml", "config_*.yml"]
-
-        for pattern in config_patterns:
-            matches = glob.glob(os.path.join(self.env_data_path, pattern))
-            if matches:
-                print(f"Auto-detected configuration file: {os.path.basename(matches[0])}")
-                return matches[0]
-
-        # Not found
-        print(f"WARNING: No configuration file auto-detected in {self.env_data_path}")
-        if os.path.exists(self.env_data_path):
-            print(f"Available files: {os.listdir(self.env_data_path)}")
-
-        return None
 
     def _update_configuration_paths(self) -> None:
         """

--- a/hydrogym/jaxfluids/env_core.py
+++ b/hydrogym/jaxfluids/env_core.py
@@ -1,21 +1,14 @@
-import glob
 import os
-from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
 
 from jaxfluids_rl.jxf_env import JAXFluidsEnv, RenderMode
 from omegaconf import OmegaConf
 
 from hydrogym.data_manager import HFDataManager
+from hydrogym.hf_env_mixin import ConfigError, HFEnvConfigMixin
 
 
-class ConfigError(Exception):
-    """Exception raised for configuration-related errors."""
-
-    pass
-
-
-class JAXFluidsFlowEnv(JAXFluidsEnv):
+class JAXFluidsFlowEnv(HFEnvConfigMixin, JAXFluidsEnv):
     """
     Base JAXFluidsFlowEnv with Hugging Face Hub integration for configuration management.
 
@@ -33,6 +26,13 @@ class JAXFluidsFlowEnv(JAXFluidsEnv):
     :type JAXFluidsEnv: _type_
     """
 
+    # Solver profile used by HFDataManager when no sentinel file is found
+    # (offline / legacy data). Must be a key of data_manager.SOLVER_PROFILES.
+    SOLVER_TYPE = "JAXFLUIDS"
+
+    # Per-backend cache directory under ~/.cache
+    HF_CACHE_NAMESPACE = "jaxfluidsgym"
+
     def _init_from_hf(self, env_config: dict) -> None:
         # Initialize HF data manager
         self.hf_repo_id = env_config.get("hf_repo_id", "dynamicslab/HydroGym-environments")
@@ -45,7 +45,7 @@ class JAXFluidsFlowEnv(JAXFluidsEnv):
             repo_id=self.hf_repo_id,
             local_fallback_dir=self.local_fallback_dir,
             use_clean_cache=self.use_clean_cache,
-            fallback_profile="JAXFLUIDS",
+            fallback_profile=self.SOLVER_TYPE,
             token=self.hf_token,
             revision=self.hf_revision,
         )
@@ -70,126 +70,3 @@ class JAXFluidsFlowEnv(JAXFluidsEnv):
 
         # Load configuration from HF
         self.conf = OmegaConf.load(self.configuration_file)
-
-    def _setup_environment_data(self) -> str:
-        """
-        Download and setup environment data from HF Hub.
-
-        First checks ~/.cache/jaxfluidsgym/ for local data, otherwise falls back to data_manager.
-
-        Returns:
-            Path to the local environment data directory.
-
-        Raises:
-            ConfigError: If environment data cannot be retrieved.
-        """
-        # Check cache directory first
-        cache_dir = Path.home() / ".cache" / "jaxfluidsgym" / self.environment_name
-        if cache_dir.exists() and cache_dir.is_dir():
-            print(f"Using cached environment data from: {cache_dir}")
-            return str(cache_dir)
-
-        # Fall back to data_manager if cache doesn't exist
-        try:
-            env_path = self.data_manager.get_environment_path(self.environment_name)
-            print(f"Using environment data from: {env_path}")
-            return env_path
-        except Exception as e:
-            raise ConfigError(f"Failed to setup environment data for {self.environment_name}: {e}")
-
-    def _resolve_configuration_file(self, config_file_input: Optional[str]) -> Optional[str]:
-        """
-        Resolve configuration file path from various input formats.
-
-        Args:
-            config_file_input: Can be:
-                - None: Auto-detect in HF environment
-                - Absolute path: Use directly
-                - Relative path starting with . or /: Use as-is
-                - Just filename: Look in HF environment directory
-
-        Returns:
-            Absolute path to configuration file, or None if not found.
-
-        Raises:
-            ConfigError: If specified configuration file is not found.
-        """
-        # Case 1: No config file specified - try to find one
-        if config_file_input is None:
-            print("No config file specified, searching in environment directory...")
-            return self._find_configuration_file()
-
-        # Case 2: Absolute path provided
-        if os.path.isabs(config_file_input):
-            if os.path.exists(config_file_input):
-                print(f"Using absolute path config file: {config_file_input}")
-                return config_file_input
-            else:
-                raise ConfigError(f"Configuration file not found: {config_file_input}")
-
-        # Case 3: Relative path from current directory (starts with ./ or ../)
-        if config_file_input.startswith("./") or config_file_input.startswith("../"):
-            abs_path = os.path.abspath(config_file_input)
-            if os.path.exists(abs_path):
-                print(f"Using config file from current directory: {abs_path}")
-                return abs_path
-            else:
-                raise ConfigError(f"Configuration file not found: {abs_path}")
-
-        # Case 4: Just a filename - look in multiple places
-        # First check current directory
-        if os.path.exists(config_file_input):
-            abs_path = os.path.abspath(config_file_input)
-            print(f"Using config file from current directory: {abs_path}")
-            return abs_path
-
-        # Then check HF environment directory
-        env_config_path = os.path.join(self.env_data_path, config_file_input)
-        if os.path.exists(env_config_path):
-            print(f"Using config file from environment: {env_config_path}")
-            return env_config_path
-
-        raise ConfigError(
-            f"Configuration file '{config_file_input}' not found in:\n"
-            f"  - Current directory: {os.getcwd()}\n"
-            f"  - Environment directory: {self.env_data_path}"
-        )
-
-    def _find_configuration_file(self) -> Optional[str]:
-        """
-        Auto-detect configuration file in the environment data directory.
-
-        Returns:
-            Path to configuration file, or None if not found.
-        """
-        # Look for specific configuration file names (most specific first)
-        config_names = [
-            "config.yaml",
-            "environment_config.yaml",
-            "env_config.yaml",
-            "environment.yaml",
-            f"{self.environment_name}.yaml",
-        ]
-
-        # Check exact names first
-        for name in config_names:
-            file_path = os.path.join(self.env_data_path, name)
-            if os.path.exists(file_path):
-                print(f"Auto-detected configuration file: {name}")
-                return file_path
-
-        # Then try patterns (but be specific - avoid catching property files)
-        config_patterns = ["config_*.yaml", "config_*.yml"]
-
-        for pattern in config_patterns:
-            matches = glob.glob(os.path.join(self.env_data_path, pattern))
-            if matches:
-                print(f"Auto-detected configuration file: {os.path.basename(matches[0])}")
-                return matches[0]
-
-        # Not found
-        print(f"WARNING: No configuration file auto-detected in {self.env_data_path}")
-        if os.path.exists(self.env_data_path):
-            print(f"Available files: {os.listdir(self.env_data_path)}")
-
-        return None

--- a/hydrogym/maia/env_core.py
+++ b/hydrogym/maia/env_core.py
@@ -6,9 +6,7 @@ This module provides the base environment class for CFD reinforcement learning
 with Hugging Face Hub integration for configuration management.
 """
 
-import glob
 import os
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 import gymnasium as gym
@@ -19,16 +17,11 @@ from einops import rearrange
 from mpi4py import MPI
 
 from hydrogym.data_manager import HFDataManager
+from hydrogym.hf_env_mixin import ConfigError, HFEnvConfigMixin
 from hydrogym.maia.mpmd_interface import MaiaInterface
 
 
-class ConfigError(Exception):
-    """Exception raised for configuration-related errors."""
-
-    pass
-
-
-class MaiaFlowEnv(gym.Env):
+class MaiaFlowEnv(HFEnvConfigMixin, gym.Env):
     """
     Base MaiaFlowEnv with Hugging Face Hub integration for configuration management.
 
@@ -50,6 +43,9 @@ class MaiaFlowEnv(gym.Env):
     """
 
     SOLVER_TYPE: str = "MAIA_LB"
+
+    # Per-backend cache directory under ~/.cache
+    HF_CACHE_NAMESPACE = "maiagym"
 
     @staticmethod
     def _resolve_num_substeps(cfg_section) -> int:
@@ -205,129 +201,6 @@ class MaiaFlowEnv(gym.Env):
                 f"Re numbers of configuration file (Re={self.cfg.maia.Re}) and "
                 f"property file (Re={self.Re}) do not match! Adjustment required!"
             )
-
-    def _setup_environment_data(self) -> str:
-        """
-        Download and setup environment data from HF Hub.
-
-        First checks ~/.cache/maiagym/ for local data, otherwise falls back to data_manager.
-
-        Returns:
-            Path to the local environment data directory.
-
-        Raises:
-            ConfigError: If environment data cannot be retrieved.
-        """
-        # Check cache directory first
-        cache_dir = Path.home() / ".cache" / "maiagym" / self.environment_name
-        if cache_dir.exists() and cache_dir.is_dir():
-            print(f"Using cached environment data from: {cache_dir}")
-            return str(cache_dir)
-
-        # Fall back to data_manager if cache doesn't exist
-        try:
-            env_path = self.data_manager.get_environment_path(self.environment_name)
-            print(f"Using environment data from: {env_path}")
-            return env_path
-        except Exception as e:
-            raise ConfigError(f"Failed to setup environment data for {self.environment_name}: {e}")
-
-    def _resolve_configuration_file(self, config_file_input: Optional[str]) -> Optional[str]:
-        """
-        Resolve configuration file path from various input formats.
-
-        Args:
-            config_file_input: Can be:
-                - None: Auto-detect in HF environment
-                - Absolute path: Use directly
-                - Relative path starting with . or /: Use as-is
-                - Just filename: Look in HF environment directory
-
-        Returns:
-            Absolute path to configuration file, or None if not found.
-
-        Raises:
-            ConfigError: If specified configuration file is not found.
-        """
-        # Case 1: No config file specified - try to find one
-        if config_file_input is None:
-            print("No config file specified, searching in environment directory...")
-            return self._find_configuration_file()
-
-        # Case 2: Absolute path provided
-        if os.path.isabs(config_file_input):
-            if os.path.exists(config_file_input):
-                print(f"Using absolute path config file: {config_file_input}")
-                return config_file_input
-            else:
-                raise ConfigError(f"Configuration file not found: {config_file_input}")
-
-        # Case 3: Relative path from current directory (starts with ./ or ../)
-        if config_file_input.startswith("./") or config_file_input.startswith("../"):
-            abs_path = os.path.abspath(config_file_input)
-            if os.path.exists(abs_path):
-                print(f"Using config file from current directory: {abs_path}")
-                return abs_path
-            else:
-                raise ConfigError(f"Configuration file not found: {abs_path}")
-
-        # Case 4: Just a filename - look in multiple places
-        # First check current directory
-        if os.path.exists(config_file_input):
-            abs_path = os.path.abspath(config_file_input)
-            print(f"Using config file from current directory: {abs_path}")
-            return abs_path
-
-        # Then check HF environment directory
-        env_config_path = os.path.join(self.env_data_path, config_file_input)
-        if os.path.exists(env_config_path):
-            print(f"Using config file from environment: {env_config_path}")
-            return env_config_path
-
-        raise ConfigError(
-            f"Configuration file '{config_file_input}' not found in:\n"
-            f"  - Current directory: {os.getcwd()}\n"
-            f"  - Environment directory: {self.env_data_path}"
-        )
-
-    def _find_configuration_file(self) -> Optional[str]:
-        """
-        Auto-detect configuration file in the environment data directory.
-
-        Returns:
-            Path to configuration file, or None if not found.
-        """
-        # Look for specific configuration file names (most specific first)
-        config_names = [
-            "config.yaml",
-            "environment_config.yaml",
-            "env_config.yaml",
-            "environment.yaml",
-            f"{self.environment_name}.yaml",
-        ]
-
-        # Check exact names first
-        for name in config_names:
-            file_path = os.path.join(self.env_data_path, name)
-            if os.path.exists(file_path):
-                print(f"Auto-detected configuration file: {name}")
-                return file_path
-
-        # Then try patterns (but be specific - avoid catching property files)
-        config_patterns = ["config_*.yaml", "config_*.yml"]
-
-        for pattern in config_patterns:
-            matches = glob.glob(os.path.join(self.env_data_path, pattern))
-            if matches:
-                print(f"Auto-detected configuration file: {os.path.basename(matches[0])}")
-                return matches[0]
-
-        # Not found
-        print(f"WARNING: No configuration file auto-detected in {self.env_data_path}")
-        if os.path.exists(self.env_data_path):
-            print(f"Available files: {os.listdir(self.env_data_path)}")
-
-        return None
 
     def _update_configuration_paths(self) -> None:
         """

--- a/hydrogym/maia/mpmd_interface.py
+++ b/hydrogym/maia/mpmd_interface.py
@@ -11,6 +11,8 @@ from typing import List, Optional, Union
 import numpy as np
 from mpi4py import MPI
 
+from hydrogym.core_external import split_comm_by_appnum
+
 # MPI tag mapping for different command types
 COMMAND_TAGS = {
     "timeStep": 0,
@@ -65,30 +67,24 @@ class MaiaInterface:
         Initialize MPI communication with m-AIA.
 
         Sets up the communicators and determines the root ranks for both
-        the Python controller and the m-AIA solver.
+        the Python controller and the m-AIA solver. The split math itself
+        lives in `hydrogym.core_external.split_comm_by_appnum` (shared
+        module for MPMD world-split strategies, audit Task 3.5); only the
+        attribute assignment stays here.
 
         Args:
             comm_world: MPI communicator, typically MPI.COMM_WORLD.
         """
-        self.appnum = comm_world.Get_attr(MPI.APPNUM)
-        rank_world = comm_world.Get_rank()
         self.worldComm = comm_world
-        self.appComm = comm_world.Split(self.appnum, rank_world)
-        self.appRank = self.appComm.Get_rank()
-        self.appNoRanks = self.appComm.Get_size()
-        self.appGroup = self.appComm.Get_group()
-
-        # Get root of other application
-        group_world = comm_world.Get_group()
-        self.appRootInWorld = group_world.Translate_ranks([self.appRoot], self.appGroup)[0]
-
-        no_app = 2
-        buff_send = np.zeros(no_app, dtype="i")
-        app_roots_in_world = np.empty_like(buff_send)
-        buff_send.fill(-1)
-        buff_send[self.appnum] = self.appRootInWorld
-        self.worldComm.Allreduce(buff_send, app_roots_in_world, op=MPI.MAX)
-        self.remoteRoot = app_roots_in_world[1 - self.appnum]
+        (
+            self.appnum,
+            self.appComm,
+            self.appRank,
+            self.appNoRanks,
+            self.appGroup,
+            self.appRootInWorld,
+            self.remoteRoot,
+        ) = split_comm_by_appnum(comm_world)
 
     def _comm_send(self, name: str, data: Union[List, np.ndarray], send_tag: bool = True) -> None:
         """

--- a/hydrogym/nek/env.py
+++ b/hydrogym/nek/env.py
@@ -20,17 +20,12 @@ from mpi4py import MPI
 from omegaconf import OmegaConf
 
 from hydrogym.data_manager import HFDataManager
+from hydrogym.hf_env_mixin import ConfigError, HFEnvConfigMixin
 
 from .configs import Config
 from .nek_lib.lglnodes import lglnodes
 from .nek_lib.nek_utils import remove_sch
 from .nek_lib.reward_logger import RewardLogger
-
-
-class ConfigError(Exception):
-    """Exception raised for configuration-related errors."""
-
-    pass
 
 
 def mpi_split(comm_world: MPI.Comm, nproc: Optional[int] = None) -> MPI.Comm:
@@ -85,7 +80,7 @@ def mpi_split(comm_world: MPI.Comm, nproc: Optional[int] = None) -> MPI.Comm:
     return sub_comm
 
 
-class NekEnv(gym.Env):
+class NekEnv(HFEnvConfigMixin, gym.Env):
     """
     Core Nek5000 environment with Gymnasium interface.
 
@@ -133,6 +128,11 @@ class NekEnv(gym.Env):
 
     metadata = {"render_modes": ["human"]}
     SOLVER_TYPE = "NEK5000"
+
+    # Per-backend cache directory under ~/.cache, and log prefix for the
+    # HFEnvConfigMixin resolution messages (Nek tags all its prints).
+    HF_CACHE_NAMESPACE = "nekgym"
+    LOG_PREFIX = "[NEK] "
     # MPI rank-binding policy passed to mpirun via MPI.Info ("bind_to").
     # Overridable via the `mpi_bind_to` env_config key (MAIA pattern).
     DEFAULT_MPI_BIND_TO = "none"
@@ -415,40 +415,19 @@ class NekEnv(gym.Env):
         print(f"  Case: {casename}")
         print(f"  Work directory: {run_folder_abs}")
 
-    def _setup_environment_data(self):
-        """
-        Download and setup environment data from HF Hub.
-
-        First checks ~/.cache/nekgym/ for local data, otherwise falls back to data_manager.
-
-        Returns:
-            Path to the local environment data directory.
-        """
-        from pathlib import Path
-
-        # Check cache directory first (like MAIA does)
-        cache_dir = Path.home() / ".cache" / "nekgym" / self.environment_name
-        if cache_dir.exists() and cache_dir.is_dir():
-            print(f"[NEK] Using cached environment data from: {cache_dir}")
-            return str(cache_dir)
-
-        # Fall back to data_manager if cache doesn't exist
-        try:
-            env_path = self.data_manager.get_environment_path(self.environment_name)
-            print(f"[NEK] Using environment data from: {env_path}")
-            return env_path
-        except Exception as e:
-            raise ConfigError(f"Failed to setup environment data for {self.environment_name}: {e}")
-
     def _resolve_configuration_file(self, config_file_input: Optional[str]) -> Optional[str]:
-        """
-        Resolve configuration file path.
+        """Resolve configuration file path.
 
-        Args:
-          config_file_input: Can be None (auto-detect), absolute path, or filename
-
-        Returns:
-          Absolute path to config file, or None if not found
+        NOTE (HFEnvConfigMixin divergence): NekEnv keeps its own SIMPLIFIED
+        resolution instead of the mixin's, deliberately. Differences from
+        the mixin default (all long-standing Nek behavior, preserved here
+        so the mixin migration stays behavior-neutral):
+          - None auto-detects only environment_config.yaml then config.yaml
+            (the mixin's _find_configuration_file also tries env_config.yaml,
+            environment.yaml, <env>.yaml and config_*.y*ml globs).
+          - A missing absolute path or unknown filename returns None (the
+            caller's "no configuration file" ConfigError then fires) where
+            the mixin raises a more specific ConfigError immediately.
         """
         # If None, look for config files in environment directory (try multiple names)
         if config_file_input is None:

--- a/hydrogym/nek/env.py
+++ b/hydrogym/nek/env.py
@@ -19,6 +19,7 @@ import pandas as pd
 from mpi4py import MPI
 from omegaconf import OmegaConf
 
+from hydrogym.core_external import ExternalProcessEnvMixin, mpi_split  # noqa: F401  (mpi_split re-exported)
 from hydrogym.data_manager import HFDataManager
 from hydrogym.hf_env_mixin import ConfigError, HFEnvConfigMixin
 
@@ -28,59 +29,7 @@ from .nek_lib.nek_utils import remove_sch
 from .nek_lib.reward_logger import RewardLogger
 
 
-def mpi_split(comm_world: MPI.Comm, nproc: Optional[int] = None) -> MPI.Comm:
-    """
-    Split MPI world into master/worker inter-communicator.
-
-    Args:
-      comm_world: MPI communicator
-      nproc: Expected number of Nek workers (for validation)
-
-    Returns:
-      Inter-communicator between controller and workers
-    """
-    mpi_rank = comm_world.Get_rank()
-    mpi_size = comm_world.Get_size()
-
-    if mpi_size < 2:
-        raise RuntimeError(
-            "MPI world size must be >= 2 to create the Nek inter-communicator. "
-            "Launch with MPMD, e.g. `mpirun -n 1 python ... : -n N ./nek5000`, "
-            "so rank 0 can connect to the Nek worker ranks."
-        )
-
-    # Validate MPI size matches nproc
-    if nproc is not None:
-        expected_size = 1 + nproc  # 1 controller + N workers
-        if mpi_size != expected_size:
-            raise RuntimeError(
-                f"MPI world size mismatch: expected {expected_size} "
-                f"(1 controller + {nproc} workers), got {mpi_size}. "
-                f"Launch with: mpirun -n 1 python ... : -n {nproc} ./nek5000"
-            )
-
-    if mpi_rank == 0:
-        color = 0
-    else:
-        color = 1
-
-    local_comm = comm_world.Split(color, mpi_rank)
-    print(
-        f"[MPI_SPLIT] World rank {mpi_rank}, color {color}, "
-        f"local_comm size: {local_comm.Get_size()}, "
-        f"local rank: {local_comm.Get_rank()}",
-        flush=True,
-    )
-
-    sub_comm = local_comm.Create_intercomm(local_leader=0, peer_comm=MPI.COMM_WORLD, remote_leader=1, tag=99)
-    print(
-        f"[MPI_SPLIT] Inter-comm created: local_size={sub_comm.Get_size()}, remote_size={sub_comm.Get_remote_size()}",
-        flush=True,
-    )
-    return sub_comm
-
-
-class NekEnv(HFEnvConfigMixin, gym.Env):
+class NekEnv(HFEnvConfigMixin, ExternalProcessEnvMixin, gym.Env):
     """
     Core Nek5000 environment with Gymnasium interface.
 
@@ -282,7 +231,7 @@ class NekEnv(HFEnvConfigMixin, gym.Env):
 
         # MPI communicator required by Nek
         comm_world = MPI.COMM_WORLD
-        self.sub_comm = mpi_split(comm_world, nproc=self.nproc)
+        self.sub_comm = self._split_mpmd_comm(comm_world, nproc=self.nproc)
 
         # Initialize the environment (this sets n_actuators, obs_per_actuator, etc.)
         self._initialize()
@@ -379,7 +328,7 @@ class NekEnv(HFEnvConfigMixin, gym.Env):
 
         # MPI communicator required by Nek
         comm_world = MPI.COMM_WORLD
-        self.sub_comm = mpi_split(comm_world, nproc=self.nproc)
+        self.sub_comm = self._split_mpmd_comm(comm_world, nproc=self.nproc)
 
         # Initialize the environment
         self._initialize()

--- a/test/mpmd_smoke_split.py
+++ b/test/mpmd_smoke_split.py
@@ -1,0 +1,108 @@
+"""MPMD smoke test for `hydrogym.core_external` split strategies (audit Task 3.5).
+
+Validates both world-split strategies live under mpirun, with no solver
+binaries required. Run from the repo root:
+
+  # Nek rank-color protocol: single-app world of 2 (rank 0 controller,
+  # rank 1 worker), inter-communicator handshake + one ping-pong message:
+  mpirun --allow-run-as-root -np 2 python test/mpmd_smoke_split.py nek
+
+  # MAIA APPNUM protocol: true MPMD, two 1-rank applications:
+  mpirun --allow-run-as-root -np 1 python test/mpmd_smoke_split.py appnum : -np 1 python test/mpmd_smoke_split.py appnum
+
+  # Nek protocol error path: wrong world size for the declared nproc
+  # (expects a clean RuntimeError; run serially):
+  python test/mpmd_smoke_split.py nek-error
+
+Each participant asserts its side of the split and, for `nek`, exchanges a
+ping-pong message over the resulting inter-communicator. Any failed check
+exits nonzero, which fails the mpirun invocation.
+"""
+
+import sys
+
+import numpy as np
+from mpi4py import MPI
+
+from hydrogym.core_external import mpi_split, split_comm_by_appnum
+
+world = MPI.COMM_WORLD
+rank = world.Get_rank()
+size = world.Get_size()
+failures = []
+
+
+def check(cond, msg):
+    if not cond:
+        failures.append(f"rank {rank}: {msg}")
+
+
+def check_nek_protocol():
+    nproc = size - 1
+    sub = mpi_split(world, nproc=nproc)
+    check(sub is not None, "mpi_split returned None")
+    check(sub.Get_remote_size() == nproc, f"remote size {sub.Get_remote_size()} != {nproc}")
+
+    # Ping-pong over the inter-communicator: controller (world rank 0)
+    # sends to remote rank 0, worker echoes it back.
+    if rank == 0:
+        sub.send(np.array([42.0], dtype="d"), dest=0, tag=7)
+        echo = sub.recv(source=0, tag=8)
+        check(echo[0] == 43.0, f"controller got {echo[0]!r}, expected 43.0")
+    else:
+        msg = sub.recv(source=0, tag=7)
+        check(msg[0] == 42.0, f"worker got {msg[0]!r}, expected 42.0")
+        sub.send(np.array([43.0], dtype="d"), dest=0, tag=8)
+
+    # nproc validation: declaring one more worker than exist must fail
+    try:
+        mpi_split(world, nproc=nproc + 1)
+        check(False, "nproc mismatch did not raise")
+    except RuntimeError as e:
+        check("world size mismatch" in str(e), f"nproc mismatch raised unexpected message: {e}")
+
+
+def check_nek_error_path():
+    """Serial (non-MPMD) invocation: mpi_split must refuse a 1-rank world."""
+    try:
+        mpi_split(world)
+        print("FAIL: single-rank mpi_split did not raise", flush=True)
+        sys.exit(1)
+    except RuntimeError as e:
+        assert "world size must be >= 2" in str(e)
+        print("OK: single-rank world rejected with MPMD launch hint", flush=True)
+
+
+def check_appnum_protocol():
+    appnum, app_comm, app_rank, app_no_ranks, app_group, app_root_in_world, remote_root = split_comm_by_appnum(world)
+    check(appnum in (0, 1), f"unexpected APPNUM {appnum}")
+    check(app_comm.Get_size() == 1, "each app should hold exactly 1 rank")
+    check(app_rank == 0, "sole rank of its app should be app rank 0")
+    check(app_root_in_world == rank, "app root in world should be this rank itself")
+    check(remote_root == 1 - rank, f"remote root {remote_root} should be the other app's sole rank")
+
+    # Each app's root announces itself over COMM_WORLD using the discovered
+    # remote root -- proves the pair (appRootInWorld, remoteRoot) is usable
+    # for the MAIA tag protocol.
+    world.send(np.array([100 + appnum], dtype="d"), dest=remote_root, tag=15)
+    peer = world.recv(source=remote_root, tag=15)
+    check(peer[0] == 100 + (1 - appnum), f"got {peer[0]!r} from remote app, expected {100 + (1 - appnum)}")
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode == "nek-error":
+        check_nek_error_path()
+    elif mode == "nek":
+        check_nek_protocol()
+    elif mode == "appnum":
+        check_appnum_protocol()
+    else:
+        print(f"FAIL: unknown mode {mode!r}", flush=True)
+        sys.exit(2)
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}", flush=True)
+        sys.exit(1)
+    print(f"OK: rank {rank} mode {mode} all checks passed", flush=True)

--- a/test/test_core_external.py
+++ b/test/test_core_external.py
@@ -1,0 +1,161 @@
+"""Unit tests for audit Task 3.5: `hydrogym.core_external`.
+
+Covers the single-rank-testable surface (error paths, mixin delegation,
+re-export identity, backend wiring). The multi-rank behavior of both split
+strategies is validated live in the MPMD smoke script
+``test/mpmd_smoke_split.py`` (run under mpirun; see its docstring) and by
+the Nek/MAIA MPMD merge-gate runs in their containers.
+"""
+
+import pytest
+
+pytest.importorskip("mpi4py")
+
+from hydrogym import core_external  # noqa: E402
+from hydrogym.core_external import ExternalProcessEnvMixin, mpi_split  # noqa: E402
+
+
+class TestMpiSplitErrorPaths:
+    def test_single_rank_world_raises(self):
+        # Single-rank MPI world (plain pytest): the < 2 guard must fire
+        # with the MPMD launch hint before anything else.
+        with pytest.raises(RuntimeError, match="world size must be >= 2"):
+            mpi_split(core_external.MPI.COMM_WORLD)
+
+    def test_single_rank_world_hint_names_mpmd_launch(self):
+        with pytest.raises(RuntimeError, match="mpirun -n 1 python"):
+            mpi_split(core_external.MPI.COMM_WORLD)
+
+
+class TestExternalProcessEnvMixin:
+    def _host(self, **attrs):
+        class _Host(ExternalProcessEnvMixin):
+            pass
+
+        for k, v in attrs.items():
+            setattr(_Host, k, v)
+        return _Host()
+
+    def test_default_knobs(self):
+        host = self._host()
+        assert host.CONTROLLER_RANK == 0
+        assert host.INTERCOMM_TAG == 99
+        assert host.MPI_SPLIT_LOG_PREFIX == "[MPI_SPLIT] "
+
+    def test_split_delegates_with_default_knobs(self, monkeypatch):
+        calls = {}
+
+        def fake_split(comm, nproc=None, controller_rank=0, intercomm_tag=99, log_prefix=""):
+            calls.update(
+                comm=comm,
+                nproc=nproc,
+                controller_rank=controller_rank,
+                intercomm_tag=intercomm_tag,
+                log_prefix=log_prefix,
+            )
+            return "SENTINEL"
+
+        monkeypatch.setattr(core_external, "mpi_split", fake_split)
+        host = self._host()
+        assert host._split_mpmd_comm("COMM", nproc=4) == "SENTINEL"
+        assert calls == {
+            "comm": "COMM",
+            "nproc": 4,
+            "controller_rank": 0,
+            "intercomm_tag": 99,
+            "log_prefix": "[MPI_SPLIT] ",
+        }
+
+    def test_split_delegates_with_overridden_knobs(self, monkeypatch):
+        calls = {}
+
+        def fake_split(comm, nproc=None, controller_rank=0, intercomm_tag=99, log_prefix=""):
+            calls.update(controller_rank=controller_rank, intercomm_tag=intercomm_tag, log_prefix=log_prefix)
+            return "SENTINEL"
+
+        monkeypatch.setattr(core_external, "mpi_split", fake_split)
+
+        class _Host(ExternalProcessEnvMixin):
+            CONTROLLER_RANK = 2
+            INTERCOMM_TAG = 123
+            MPI_SPLIT_LOG_PREFIX = "[X] "
+
+        assert _Host()._split_mpmd_comm("COMM") == "SENTINEL"
+        assert calls == {"controller_rank": 2, "intercomm_tag": 123, "log_prefix": "[X] "}
+
+
+class TestBackendWiring:
+    def test_nek_env_uses_mixin(self):
+        mod = pytest.importorskip("hydrogym.nek.env")
+        assert issubclass(mod.NekEnv, ExternalProcessEnvMixin)
+        # Split now goes through the mixin extension point
+        assert "_split_mpmd_comm" not in vars(mod.NekEnv), "NekEnv overrides the mixin split"
+        src = open(mod.__file__).read()
+        assert "self.sub_comm = self._split_mpmd_comm(" in src, "NekEnv must delegate to the mixin split"
+        assert "remote_leader" not in src, "split handshake should live only in core_external"
+
+    def test_nek_mpi_split_reexport_identity(self):
+        # hydrogym.nek.mpi_split must keep resolving to the shared
+        # implementation (public API + monkeypatch idiom).
+        nek_init = pytest.importorskip("hydrogym.nek")
+        assert nek_init.mpi_split is mpi_split
+
+    def test_maia_init_comm_delegates(self):
+        mod = pytest.importorskip("hydrogym.maia.mpmd_interface")
+        src = open(mod.__file__).read()
+        assert "split_comm_by_appnum(comm_world)" in src, "init_comm must delegate the split math"
+        # The split math itself must live only in core_external now
+        assert "Allreduce" not in src, "Allreduce-based root discovery should live only in core_external"
+        assert "Translate_ranks" not in src
+        assert "Split(" not in src.replace("split_comm_by_appnum(", ""), "no local Split calls should remain"
+        # Attribute contract preserved (consumed by env_core / MaiaInterface)
+        for attr in (
+            "worldComm",
+            "appComm",
+            "appRank",
+            "appNoRanks",
+            "appGroup",
+            "appnum",
+            "appRootInWorld",
+            "remoteRoot",
+        ):
+            assert f"self.{attr}" in src
+
+    def test_maia_split_helper_is_core_external(self):
+        from hydrogym.maia import mpmd_interface
+
+        assert mpmd_interface.split_comm_by_appnum is core_external.split_comm_by_appnum
+
+
+class TestSplitFixes:
+    """Pin the two latent bugs the MPMD smoke script exposed (audit Task 3.5).
+
+    Both were only correct on the production path because one specific app
+    layout happened to mask them; the smoke script runs both sides in
+    Python and they deadlocked / produced remote_root=-1.
+    """
+
+    def test_mpi_split_remote_leader_not_hardcoded_one(self):
+        # Original hardcoded remote_leader=1 on BOTH sides; a Python worker
+        # (color 1) would contact itself and hang the controller's
+        # Create_intercomm. Must select the other app's leader per side.
+        src = open(core_external.__file__).read()
+        assert "remote_leader=1 - color" in src
+        assert "remote_leader=1," not in src
+
+    def test_appnum_root_translation_direction(self):
+        # Original translated world-rank 0 INTO the app group (MPI_UNDEFINED
+        # for every app but 0). Must translate app rank 0 -> world.
+        src = open(core_external.__file__).read()
+        assert "app_group.Translate_ranks([app_root], group_world)" in src
+        assert "group_world.Translate_ranks([app_root], app_group)" not in src
+
+
+class TestSplitCommByAppnumSingleApp:
+    """split_comm_by_appnum on a non-MPMD single-rank world: APPNUM is None
+    (or 0 depending on MPI implementation), so full validation happens in
+    the MPMD smoke script; here we only pin that the helper is exported and
+    the module imports cleanly without solver binaries."""
+
+    def test_helper_importable_without_solver(self):
+        assert callable(core_external.split_comm_by_appnum)

--- a/test/test_hf_data_manager_token_revision.py
+++ b/test/test_hf_data_manager_token_revision.py
@@ -25,6 +25,7 @@ import pytest
 
 pytest.importorskip("huggingface_hub")
 
+from hydrogym import core_external as core_external_mod  # noqa: E402
 from hydrogym import data_manager as dm_mod  # noqa: E402
 from hydrogym.data_manager import HFDataManager  # noqa: E402
 
@@ -169,7 +170,7 @@ class TestNekEnvConfigThreading:
         monkeypatch.setattr(nek_env_mod.NekEnv, "_update_configuration_paths", lambda self: None)
         monkeypatch.setattr(nek_env_mod.NekEnv, "_apply_runtime_overrides", lambda self, ec: None)
         monkeypatch.setattr(nek_env_mod.NekEnv, "_create_session_file_early", lambda self: None)
-        monkeypatch.setattr(nek_env_mod, "mpi_split", lambda comm, nproc=None: None)
+        monkeypatch.setattr(core_external_mod, "mpi_split", lambda comm, nproc=None, **kw: None)
         monkeypatch.setattr(nek_env_mod.NekEnv, "_initialize", lambda self: None)
         monkeypatch.chdir(tmp_path)
         return {"recorded": recorded, "NekEnv": nek_env_mod.NekEnv}

--- a/test/test_hf_env_mixin.py
+++ b/test/test_hf_env_mixin.py
@@ -215,3 +215,46 @@ class TestNekMigration:
         # `from hydrogym.nek.env import ConfigError` / `hydrogym.nek.ConfigError`
         # must keep resolving to the shared type
         assert mod.ConfigError is ConfigError
+
+
+class TestMaiaMigration:
+    """Pin the Task 3.4 migration: MaiaFlowEnv uses the mixin's methods
+    (its local copies are deleted), keeping its namespace/profile."""
+
+    def test_uses_mixin(self):
+        mod = pytest.importorskip("hydrogym.maia.env_core")
+        assert issubclass(mod.MaiaFlowEnv, HFEnvConfigMixin)
+        for name in ("_setup_environment_data", "_resolve_configuration_file", "_find_configuration_file"):
+            assert name not in vars(mod.MaiaFlowEnv), f"{name} still overridden locally"
+        assert mod.MaiaFlowEnv.HF_CACHE_NAMESPACE == "maiagym"
+        assert mod.MaiaFlowEnv.SOLVER_TYPE == "MAIA_LB"
+
+    def test_config_error_is_shared_type(self):
+        mod = pytest.importorskip("hydrogym.maia.env_core")
+        # `from hydrogym.maia.env_core import ConfigError` (used by the
+        # maia envs) must keep resolving to the shared type
+        assert mod.ConfigError is ConfigError
+
+    def test_setup_uses_nek_cache_and_prefix(self, monkeypatch, tmp_path, capsys):
+        """The mixin's LOG_PREFIX hook reproduces the old [NEK]-tagged
+        print lines exactly (byte-for-byte vs the pre-migration copy)."""
+        import pathlib
+
+        monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: tmp_path))
+
+        cache = tmp_path / ".cache" / "nekgym" / "MyEnv"
+        cache.mkdir(parents=True)
+        dm = _StubDataManager(env_path="/hf/MyEnv")
+        host = _Host("MyEnv", None, dm)
+        host.HF_CACHE_NAMESPACE = "nekgym"
+        host.LOG_PREFIX = "[NEK] "
+
+        assert host._setup_environment_data() == str(cache)
+        assert "[NEK] Using cached environment data from:" in capsys.readouterr().out
+        assert dm.calls == []  # never consulted
+
+        # And a prefix-less host (jax/jaxfluids/maia pattern) prints bare
+        dm2 = _StubDataManager(env_path="/hf/MyEnv")
+        host2 = _Host("MyEnv", None, dm2)
+        assert host2._setup_environment_data() == "/hf/MyEnv"
+        assert "[NEK]" not in capsys.readouterr().out

--- a/test/test_hf_env_mixin.py
+++ b/test/test_hf_env_mixin.py
@@ -176,3 +176,42 @@ class TestJaxfluidsMigration:
         mod = pytest.importorskip("hydrogym.jaxfluids.env_core")
         # Same exception object: existing `except ConfigError` sites keep working
         assert mod.ConfigError is ConfigError
+
+
+class TestJaxMigration:
+    """Pin the Task 3.2 migration: JAXFlowEnv uses the mixin's methods
+    (its local copies are deleted), keeping its namespace/profile."""
+
+    def test_uses_mixin(self):
+        mod = pytest.importorskip("hydrogym.jax.env_core")
+        assert issubclass(mod.JAXFlowEnv, HFEnvConfigMixin)
+        for name in ("_setup_environment_data", "_resolve_configuration_file", "_find_configuration_file"):
+            assert name not in vars(mod.JAXFlowEnv), f"{name} still overridden locally"
+        assert mod.JAXFlowEnv.HF_CACHE_NAMESPACE == "jaxgym"
+        assert mod.JAXFlowEnv.SOLVER_TYPE == "JAX"
+
+    def test_config_error_is_shared_type(self):
+        mod = pytest.importorskip("hydrogym.jax.env_core")
+        assert mod.ConfigError is ConfigError
+
+
+class TestNekMigration:
+    """Pin the Task 3.3 migration: NekEnv uses the mixin's
+    _setup_environment_data (its local copy is deleted) but KEEPS its own
+    simplified _resolve_configuration_file as a documented divergence."""
+
+    def test_uses_mixin_for_setup(self):
+        mod = pytest.importorskip("hydrogym.nek.env")
+        assert issubclass(mod.NekEnv, HFEnvConfigMixin)
+        assert "_setup_environment_data" not in vars(mod.NekEnv), "still overridden locally"
+        assert mod.NekEnv.HF_CACHE_NAMESPACE == "nekgym"
+        assert mod.NekEnv.LOG_PREFIX == "[NEK] "
+        assert mod.NekEnv.SOLVER_TYPE == "NEK5000"
+        # Intentional divergence: Nek's simplified resolver is retained
+        assert "_resolve_configuration_file" in vars(mod.NekEnv)
+
+    def test_config_error_is_shared_type(self):
+        mod = pytest.importorskip("hydrogym.nek.env")
+        # `from hydrogym.nek.env import ConfigError` / `hydrogym.nek.ConfigError`
+        # must keep resolving to the shared type
+        assert mod.ConfigError is ConfigError

--- a/test/test_hf_env_mixin.py
+++ b/test/test_hf_env_mixin.py
@@ -1,0 +1,178 @@
+"""Unit tests for audit Task 3.1: `HFEnvConfigMixin`.
+
+The four HF-backed backends (jaxfluids, jax, maia, nek) each carried a
+private copy of `_setup_environment_data` / `_resolve_configuration_file` /
+`_find_configuration_file`, differing only in the ~/.cache namespace. The
+mixin centralizes them; Task 3.1 migrates JAX-Fluids onto it first.
+
+The mixin tests below run on a trivial host class with a stubbed
+`data_manager` -- no JAX-Fluids install, no HF download. The JAX-Fluids
+migration is pinned by a source/subclass test (guarded by importorskip so
+it skips wherever jaxfluids isn't installed).
+"""
+
+import pytest
+
+pytest.importorskip("huggingface_hub")
+
+from hydrogym.hf_env_mixin import ConfigError, HFEnvConfigMixin  # noqa: E402
+
+
+class _Host(HFEnvConfigMixin):
+    """Trivial consumer of the mixin: just the attributes the mixin needs."""
+
+    HF_CACHE_NAMESPACE = "testgym"
+
+    def __init__(self, environment_name, env_data_path, data_manager):
+        self.environment_name = environment_name
+        self.env_data_path = env_data_path
+        self.data_manager = data_manager
+
+
+class _StubDataManager:
+    def __init__(self, env_path=None, error=None):
+        self.env_path = env_path
+        self.error = error
+        self.calls = []
+
+    def get_environment_path(self, environment_name):
+        self.calls.append(environment_name)
+        if self.error is not None:
+            raise self.error
+        return self.env_path
+
+
+@pytest.fixture
+def fake_home(monkeypatch, tmp_path):
+    """Point `Path.home()` inside the mixin module at a tmp dir."""
+    import pathlib
+
+    monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: tmp_path))
+    return tmp_path
+
+
+class TestSetupEnvironmentData:
+    def test_cache_hit_short_circuits_data_manager(self, fake_home):
+        cache = fake_home / ".cache" / "testgym" / "MyEnv"
+        cache.mkdir(parents=True)
+        dm = _StubDataManager(env_path="/should/not/be/used")
+
+        host = _Host("MyEnv", None, dm)
+        assert host._setup_environment_data() == str(cache)
+        assert dm.calls == []  # never consulted
+
+    def test_cache_miss_falls_back_to_data_manager(self, fake_home):
+        dm = _StubDataManager(env_path="/hf/snapshot/MyEnv")
+        host = _Host("MyEnv", None, dm)
+        assert host._setup_environment_data() == "/hf/snapshot/MyEnv"
+        assert dm.calls == ["MyEnv"]
+
+    def test_data_manager_failure_wraps_in_config_error(self, fake_home):
+        dm = _StubDataManager(error=RuntimeError("hub down"))
+        host = _Host("MyEnv", None, dm)
+        with pytest.raises(ConfigError, match="Failed to setup environment data for MyEnv"):
+            host._setup_environment_data()
+
+    def test_namespace_is_parameterized(self, fake_home):
+        class _OtherHost(_Host):
+            HF_CACHE_NAMESPACE = "othergym"
+
+        cache = fake_home / ".cache" / "othergym" / "MyEnv"
+        cache.mkdir(parents=True)
+        dm = _StubDataManager(env_path="/hf/MyEnv")
+
+        # _OtherHost hits its own namespace; _Host with the same tree misses
+        assert _OtherHost("MyEnv", None, dm)._setup_environment_data() == str(cache)
+        assert _Host("MyEnv", None, dm)._setup_environment_data() == "/hf/MyEnv"
+
+
+class TestResolveConfigurationFile:
+    def _make(self, tmp_path, env_files=()):
+        env_dir = tmp_path / "env"
+        env_dir.mkdir(exist_ok=True)
+        for f in env_files:
+            (env_dir / f).write_text("env: {}")
+        return _Host("MyEnv", str(env_dir), _StubDataManager())
+
+    def test_none_triggers_autodetect(self, tmp_path):
+        host = self._make(tmp_path, env_files=["config.yaml"])
+        assert host._resolve_configuration_file(None) == str(tmp_path / "env" / "config.yaml")
+
+    def test_absolute_path_exists(self, tmp_path):
+        cfg = tmp_path / "elsewhere.yaml"
+        cfg.write_text("env: {}")
+        assert self._make(tmp_path)._resolve_configuration_file(str(cfg)) == str(cfg)
+
+    def test_absolute_path_missing_raises(self, tmp_path):
+        with pytest.raises(ConfigError, match="Configuration file not found"):
+            self._make(tmp_path)._resolve_configuration_file(str(tmp_path / "nope.yaml"))
+
+    def test_dot_relative_path(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text("env: {}")
+        monkeypatch.chdir(tmp_path)
+        assert self._make(tmp_path)._resolve_configuration_file("./cfg.yaml") == str(cfg)
+
+    def test_dot_relative_missing_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(ConfigError, match="Configuration file not found"):
+            self._make(tmp_path)._resolve_configuration_file("./nope.yaml")
+
+    def test_bare_filename_in_cwd(self, tmp_path, monkeypatch):
+        (tmp_path / "cfg.yaml").write_text("env: {}")
+        monkeypatch.chdir(tmp_path)
+        assert self._make(tmp_path)._resolve_configuration_file("cfg.yaml") == str(tmp_path / "cfg.yaml")
+
+    def test_bare_filename_in_env_dir(self, tmp_path):
+        host = self._make(tmp_path, env_files=["custom.yaml"])
+        assert host._resolve_configuration_file("custom.yaml") == str(tmp_path / "env" / "custom.yaml")
+
+    def test_bare_filename_nowhere_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(ConfigError, match="not found in"):
+            self._make(tmp_path)._resolve_configuration_file("custom.yaml")
+
+
+class TestFindConfigurationFile:
+    def _make(self, tmp_path, env_files=()):
+        env_dir = tmp_path / "env"
+        env_dir.mkdir(exist_ok=True)
+        for f in env_files:
+            (env_dir / f).write_text("env: {}")
+        return _Host("MyEnv", str(env_dir), _StubDataManager()), env_dir
+
+    def test_exact_name_priority(self, tmp_path):
+        host, env_dir = self._make(tmp_path, env_files=["environment.yaml", "config.yaml"])
+        # config.yaml is first in the priority list
+        assert host._find_configuration_file() == str(env_dir / "config.yaml")
+
+    def test_environment_name_yaml_fallback(self, tmp_path):
+        host, env_dir = self._make(tmp_path, env_files=["MyEnv.yaml"])
+        assert host._find_configuration_file() == str(env_dir / "MyEnv.yaml")
+
+    def test_pattern_glob(self, tmp_path):
+        host, env_dir = self._make(tmp_path, env_files=["config_timestep10.yaml"])
+        assert host._find_configuration_file() == str(env_dir / "config_timestep10.yaml")
+
+    def test_nothing_found_returns_none(self, tmp_path):
+        host, _ = self._make(tmp_path, env_files=["readme.md"])
+        assert host._find_configuration_file() is None
+
+
+class TestJaxfluidsMigration:
+    """Pin the Task 3.1 migration: JAXFluidsFlowEnv uses the mixin's methods
+    (its local copies are deleted), and its namespace/profile survive."""
+
+    def test_uses_mixin(self):
+        mod = pytest.importorskip("hydrogym.jaxfluids.env_core")
+        assert issubclass(mod.JAXFluidsFlowEnv, HFEnvConfigMixin)
+        # The three methods must be inherited, not overridden locally
+        for name in ("_setup_environment_data", "_resolve_configuration_file", "_find_configuration_file"):
+            assert name not in vars(mod.JAXFluidsFlowEnv), f"{name} still overridden locally"
+        assert mod.JAXFluidsFlowEnv.HF_CACHE_NAMESPACE == "jaxfluidsgym"
+        assert mod.JAXFluidsFlowEnv.SOLVER_TYPE == "JAXFLUIDS"
+
+    def test_config_error_is_shared_type(self):
+        mod = pytest.importorskip("hydrogym.jaxfluids.env_core")
+        # Same exception object: existing `except ConfigError` sites keep working
+        assert mod.ConfigError is ConfigError

--- a/test/test_jax_env_core.py
+++ b/test/test_jax_env_core.py
@@ -45,11 +45,12 @@ def fake_home(monkeypatch, tmp_path):
     """Point Path.home() at tmp_path for the ~/.cache/<namespace> lookup.
 
     NOTE: this temporarily patches pathlib.Path.home() process-wide (the
-    module imports Path from pathlib); monkeypatch restores it afterwards.
+    HFEnvConfigMixin resolution logic lives in hydrogym.hf_env_mixin, whose
+    Path is the same pathlib.Path class); monkeypatch restores it afterwards.
     """
-    from hydrogym.jax import env_core
+    import pathlib
 
-    monkeypatch.setattr(env_core.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(pathlib.Path, "home", staticmethod(lambda: tmp_path))
     return tmp_path
 
 

--- a/test/test_nek_mpi_bind_to.py
+++ b/test/test_nek_mpi_bind_to.py
@@ -25,6 +25,7 @@ from hydrogym.nek.env import NekEnv  # noqa: E402
 
 @pytest.fixture
 def real_init_from_hf(monkeypatch, tmp_path):
+    from hydrogym import core_external
     from hydrogym.nek import env as nek_env_mod
 
     (tmp_path / "config.yaml").write_text("env: {}\n")
@@ -34,7 +35,9 @@ def real_init_from_hf(monkeypatch, tmp_path):
     monkeypatch.setattr(NekEnv, "_update_configuration_paths", lambda self: None)
     monkeypatch.setattr(NekEnv, "_apply_runtime_overrides", lambda self, ec: None)
     monkeypatch.setattr(NekEnv, "_create_session_file_early", lambda self: None)
-    monkeypatch.setattr(nek_env_mod, "mpi_split", lambda comm, nproc=None: None)
+    # NekEnv delegates the split to ExternalProcessEnvMixin._split_mpmd_comm,
+    # which resolves mpi_split from core_external's module namespace.
+    monkeypatch.setattr(core_external, "mpi_split", lambda comm, nproc=None, **kw: None)
     monkeypatch.setattr(NekEnv, "_initialize", lambda self: None)
     monkeypatch.chdir(tmp_path)
 

--- a/test/test_nek_reward_aggregation.py
+++ b/test/test_nek_reward_aggregation.py
@@ -21,6 +21,7 @@ import pytest
 pytest.importorskip("mpi4py")
 pytest.importorskip("pandas")
 
+from hydrogym import core_external  # noqa: E402
 from hydrogym.nek.env import NekEnv  # noqa: E402
 
 
@@ -78,8 +79,10 @@ class TestEnvConfigLevelOverride:
         monkeypatch.setattr(NekEnv, "_apply_runtime_overrides", lambda self, ec: None)
         monkeypatch.setattr(NekEnv, "_create_session_file_early", lambda self: None)
         # _init_from_hf finishes with the MPI split and solver wiring, which
-        # needs a real MPMD world -- stub both out.
-        monkeypatch.setattr(nek_env_mod, "mpi_split", lambda comm, nproc=None: None)
+        # needs a real MPMD world -- stub both out. NekEnv delegates the
+        # split to ExternalProcessEnvMixin._split_mpmd_comm, which resolves
+        # mpi_split from core_external's module namespace.
+        monkeypatch.setattr(core_external, "mpi_split", lambda comm, nproc=None, **kw: None)
         monkeypatch.setattr(NekEnv, "_initialize", lambda self: None)
         # Keep run-folder creation inside tmp_path
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Fourth PR in the sequential \`hydrogym-audit-v2\` stack. Targets #285 (Phase 2).

## Scope (Phase 3 — shared-mixin extraction, Tasks 3.1-3.5)

Each backend independently reimplemented the same HuggingFace Hub
data-staging logic (with subtle drift between them) and, for the two
MPMD backends, the same MPI comm-split logic. This phase extracts both
into shared mixins and migrates every backend onto them:

- 3.1: extract \`HFEnvConfigMixin\`; migrate JAX-Fluids onto it
- 3.2: migrate \`JAXFlowEnv\`
- 3.3: migrate \`NekEnv\`
- 3.4: migrate \`MaiaFlowEnv\`
- 3.5: extract \`ExternalProcessEnvMixin\` for MPMD comm splits (MAIA + Nek)

## Verified

- \`ruff check .\`, \`ruff format --check .\`, \`isort . --check-only --diff\`,
  codespell all clean
- \`import hydrogym.hf_env_mixin\` and \`from hydrogym.hf_env_mixin import
  HFEnvConfigMixin\` verified working; \`core_external.py\` syntax-checked
  (its \`mpi4py\` import is an optional extra, not installed in the plain
  lint venv used here — exercised for real via the actual MPMD backends
  in the devcontainer verification passes documented in
  \`HYDROGYM_ENGINEERING_AUDIT_v2.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)