### PR TITLE
Audit Phase 7: docstring coverage rollout to 100%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,23 @@ permissions:
   contents: read
 
 jobs:
+  docstring-coverage:
+    # Audit Task 7.2: enforce the docstring-coverage floor that the Phase 7
+    # rollout achieved (99.8% over the default target set), so it cannot
+    # silently regress again the way it had across backends before the audit
+    # (jax/env_core.py was 24%). The measurement tool is stdlib-only, so this
+    # job needs no dependencies and runs in seconds. To lower the floor,
+    # update both the number here and the rationale in
+    # HYDROGYM_ENGINEERING_AUDIT_v2.md's Phase 7 section.
+    name: Docstring coverage floor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    container: python:3.12-slim
+    steps:
+      - uses: actions/checkout@v4
+      - name: Measure docstring coverage
+        run: python test/measure_docstrings.py --fail-under 99
+
   developer-template-skeletons:
     # Audit Task 4.4: the reference skeletons under
     # examples/developer_templates/ must stay runnable in the PLAIN CI tier

--- a/hydrogym/core.py
+++ b/hydrogym/core.py
@@ -8,15 +8,43 @@ from numpy.typing import ArrayLike
 
 
 class ActuatorBase:
+    """Base class for a single actuator driving the flow.
+
+    An actuator holds a scalar state ``x`` that the controller updates each
+    step. Subclasses override :meth:`step` to define how the applied state
+    evolves from the requested input (e.g. first-order smoothing towards the
+    input over the flow's ``TAU`` timescale) rather than setting it directly.
+
+    Attributes:
+        x: Current actuator state.
+    """
+
     def __init__(self, state=0.0, **kwargs):
+        """Initialize the actuator to a constant state.
+
+        Args:
+            state: Initial actuator state. Defaults to 0.0.
+            **kwargs: Ignored; accepted so subclasses can pass through
+                shared configuration dictionaries unchanged.
+        """
         self.x = state
 
     @property
     def state(self) -> float:
+        """Return the current actuator state.
+
+        Returns:
+            float: Current value of the actuator state ``x``.
+        """
         return self.x
 
     @state.setter
     def state(self, u: float):
+        """Set the actuator state directly.
+
+        Args:
+            u (float): New actuator state.
+        """
         self.x = u
 
     def step(self, u: float, dt: float):
@@ -46,6 +74,30 @@ class PDEBase(metaclass=abc.ABCMeta):
     BCType = TypeVar("BCType")
 
     def __init__(self, **config):
+        """Configure the PDE from keyword arguments and prepare it for use.
+
+        Loads the mesh, initializes the state, and resets the model to its
+        initial condition. Also handles the ``restart`` option: a single
+        checkpoint path (string) is loaded immediately, while a list/tuple of
+        paths loads the first one as the default state (FlowEnv handles
+        random selection among the full set at reset time).
+
+        Subclasses are expected to ``.pop`` their own config keys before
+        calling ``super().__init__``; any keys left in ``config`` at this
+        point are almost certainly typos or unsupported options, so a
+        warning is emitted rather than silently ignoring them.
+
+        Args:
+            **config: Configuration options. PDEBase itself consumes:
+                - mesh (str): Mesh name passed to ``load_mesh``.
+                  Defaults to ``DEFAULT_MESH``.
+                - restart (str | list | tuple): Checkpoint file(s) to load.
+                  Defaults to None (start from the initial condition).
+
+        Raises:
+            ValueError: If ``restart`` is neither a string nor a list/tuple
+                of strings.
+        """
         # Consume the keys PDEBase itself owns. Subclasses consume their own
         # keys (with .pop) before calling super().__init__; anything left in
         # `config` after that is almost certainly a typo'd or unsupported
@@ -154,10 +206,21 @@ class PDEBase(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def save_checkpoint(self, filename: str):
+        """Write the current PDE state to a checkpoint file.
+
+        Args:
+            filename (str): Path of the checkpoint file to write.
+        """
         pass
 
     @abc.abstractmethod
     def load_checkpoint(self, filename: str):
+        """Load the PDE state from a checkpoint file.
+
+        Args:
+            filename (str): Path of a checkpoint previously written by
+                ``save_checkpoint``.
+        """
         pass
 
     @abc.abstractmethod
@@ -187,6 +250,7 @@ class PDEBase(metaclass=abc.ABCMeta):
 
     @property
     def control_state(self) -> Iterable[ArrayLike]:
+        """Return the current control vector (one entry per actuator)."""
         return [a.state for a in self.actuators]
 
     def set_control(self, act: ArrayLike = None):
@@ -256,15 +320,19 @@ class EvaluationActor:
 
 
 class CallbackBase:
+    """Base class for things that happen every so often in the simulation.
+
+    Concrete callbacks (e.g. saving output for visualization or writing log
+    entries) are invoked by ``TransientSolver.solve`` each iteration; the
+    default ``__call__`` acts only every ``interval`` iterations.
+
+    TODO: Add a ControllerCallback
+    """
+
     def __init__(self, interval: int = 1):
         """
-        Base class for things that happen every so often in the simulation
-        (e.g. save output for visualization or write some info to a log file).
-
         Args:
             interval (int, optional): How often to take action. Defaults to 1.
-
-        TODO: Add a ControllerCallback
         """
         self.interval = interval
 
@@ -290,6 +358,13 @@ class TransientSolver:
     """Time-stepping code for updating the transient PDE"""
 
     def __init__(self, flow: PDEBase, dt: float = None):
+        """Bind the solver to a flow and select the time step.
+
+        Args:
+            flow (PDEBase): The PDE model to be time-stepped.
+            dt (float, optional): Time step to use. Defaults to the flow's
+                ``DEFAULT_DT`` if not given.
+        """
         self.flow = flow
         if dt is None:
             dt = flow.DEFAULT_DT
@@ -387,7 +462,66 @@ class TransientSolver:
 
 
 class FlowEnv(gym.Env):
+    """Gymnasium environment wrapping a PDE model and its transient solver.
+
+    Each ``step`` advances the flow and returns the (negated, time-scaled)
+    objective as the reward. Reaching the configured step budget is reported
+    as a truncation, not a termination. Optionally, one ``step`` can advance
+    the simulation by several solver substeps while holding the action
+    constant, with per-substep rewards aggregated by a configurable rule.
+
+    Attributes:
+        flow: The underlying PDE model.
+        solver: The transient solver driving the PDE.
+        callbacks: Callbacks invoked after each step.
+        max_steps: Episode length in environment steps.
+        iter: Total number of solver steps taken since the last reset.
+        num_substeps: Solver steps per environment step.
+        reward_aggregation: How per-substep objectives are combined
+            ('mean', 'sum', or 'median').
+        restart_checkpoints: List of checkpoint paths (if any) available
+            for random selection on reset, else None.
+        initial_states: Preloaded flow states to reset to.
+    """
+
     def __init__(self, env_config: dict):
+        """Build the flow and solver from ``env_config`` and set up spaces.
+
+        Multi-substep actuation is configured via ``actuation_config``. The
+        old keys ``num_sim_substeps_per_actuation`` and
+        ``reward_aggreation_rule`` (misspelled) are still accepted but emit a
+        DeprecationWarning; their non-deprecated replacements are
+        ``num_substeps`` and ``reward_aggregation``.
+
+        The ``restart`` entry of ``flow_config`` selects the initial states:
+        a string means a single checkpoint (already loaded by the flow), a
+        list/tuple means several checkpoints, all of which are preloaded as
+        candidate initial states (reset picks one at random).
+
+        Args:
+            env_config (dict): Configuration dictionary containing:
+                - flow (type): Callable (usually a PDEBase subclass)
+                  constructing the flow from ``flow_config``.
+                - flow_config (dict, optional): Keyword configuration passed
+                  to the flow constructor.
+                - solver (type): Callable (usually a TransientSolver
+                  subclass) constructing the solver as
+                  ``solver(flow, **solver_config)``.
+                - solver_config (dict, optional): Keyword configuration
+                  passed to the solver.
+                - callbacks (Iterable[CallbackBase], optional): Callbacks
+                  invoked after each step. Defaults to [].
+                - max_steps (int, optional): Steps per episode. Defaults to
+                  1e6.
+                - actuation_config (dict, optional): Multi-substep options
+                  (see above). Defaults to one substep and 'mean'
+                  aggregation.
+
+        Raises:
+            ValueError: If ``num_substeps < 1``, if ``reward_aggregation``
+                is not 'mean', 'sum', or 'median', or if ``restart`` is
+                neither a string nor a list/tuple.
+        """
         self.flow: PDEBase = env_config.get("flow")(**env_config.get("flow_config", {}))
         self.solver: TransientSolver = env_config.get("solver")(self.flow, **env_config.get("solver_config", {}))
         self.callbacks: Iterable[CallbackBase] = env_config.get("callbacks", [])
@@ -464,6 +598,12 @@ class FlowEnv(gym.Env):
         )
 
     def set_callbacks(self, callbacks: Iterable[CallbackBase]):
+        """Replace the environment's callbacks.
+
+        Args:
+            callbacks (Iterable[CallbackBase]): Callbacks to invoke after
+                each step.
+        """
         self.callbacks = callbacks
 
     def step(self, action: Iterable[ArrayLike] = None) -> Tuple[ArrayLike, float, bool, bool, dict]:
@@ -483,6 +623,7 @@ class FlowEnv(gym.Env):
         else:
             # Multi-substep mode
             def constant_controller(t, y):
+                """Return the (fixed) action, holding it constant across substeps."""
                 return action
 
             _, rewards = self.solver.solve(
@@ -536,9 +677,22 @@ class FlowEnv(gym.Env):
             return np.array([obs], dtype=np.float64)
 
     def get_reward(self):
+        """Return the reward for the current flow state.
+
+        The reward is the negative of the flow's objective function (which
+        is to be minimized), scaled by the solver time step.
+
+        Returns:
+            float: Reward ``-dt * evaluate_objective()``.
+        """
         return -self.solver.dt * self.flow.evaluate_objective()
 
     def check_complete(self):
+        """Check whether the episode has exceeded its step budget.
+
+        Returns:
+            bool: True if the number of elapsed steps exceeds ``max_steps``.
+        """
         return self.iter > self.max_steps
 
     def reset(self, seed=None, options=None) -> Tuple[ArrayLike, dict]:
@@ -574,8 +728,17 @@ class FlowEnv(gym.Env):
         return obs, info
 
     def render(self, mode="human", **kwargs):
+        """Render the current PDE state.
+
+        Args:
+            mode (str, optional): Render mode passed through to the flow.
+                Defaults to "human".
+            **kwargs: Additional keyword arguments forwarded to
+                ``flow.render``.
+        """
         self.flow.render(mode=mode, **kwargs)
 
     def close(self):
+        """Close the environment by closing all registered callbacks."""
         for cb in self.callbacks:
             cb.close()

--- a/hydrogym/core_external.py
+++ b/hydrogym/core_external.py
@@ -48,6 +48,12 @@ except ImportError:  # pragma: no cover - exercised only without mpi4py
 
 
 def _require_mpi():
+    """Raise a clear ImportError if mpi4py is unavailable.
+
+    Called at the top of every public entry point in this module so the
+    no-mpi4py path fails loudly at call time instead of at import time
+    (the module itself imports fine without mpi4py).
+    """
     if not MPI_AVAILABLE:
         raise ImportError(
             "mpi4py is required for MPMD communicator splitting but is not installed. "

--- a/hydrogym/firedrake/actuator.py
+++ b/hydrogym/firedrake/actuator.py
@@ -29,20 +29,43 @@ class DampedActuator(ActuatorBase):
         damping: float,
         state: float = 0.0,
     ):
+        """Initialize the actuator.
+
+        Args:
+            damping (float): Damping coefficient ``k/m = 1/tau``, i.e. the
+                inverse time constant of the low-pass filter.
+            state (float, optional): Initial actuator state. Default 0.0.
+        """
         self.alpha = damping
         self._x = pyadjoint.AdjFloat(state)
         self.x = fd.Constant(state)
 
     @property
     def state(self) -> np.ndarray:
+        """Current actuator state as a scalar value."""
         return self.x.values()[0]
 
     @state.setter
     def state(self, u: float):
+        """Set the actuator state directly.
+
+        Args:
+            u (float): New state value.
+        """
         self._x = pyadjoint.AdjFloat(u)
         self.x.assign(u)
 
     def step(self, u: float, dt: float):
-        """Update the state of the actuator"""
+        """Advance the actuator state by ``dt`` with control input ``u``.
+
+        Applies the exact zero-order-hold solution of the first-order
+        damped dynamics: ``x <- u + (x - u) * exp(-alpha * dt)``, and
+        annotates the update for use with Firedrake/Pyadjoint
+        differentiable programming.
+
+        Args:
+            u (float): Control input (target state) held over the step.
+            dt (float): Time step size.
+        """
         self._x = u + (self._x - u) * exp(-self.alpha * dt)
         self.x.assign(self._x, annotate=True)

--- a/hydrogym/firedrake/envs/cavity/flow.py
+++ b/hydrogym/firedrake/envs/cavity/flow.py
@@ -11,6 +11,16 @@ from hydrogym.firedrake import FlowConfig, ObservationFunction, ScaledDirichletB
 
 
 class Cavity(FlowConfig):
+    """Open cavity flow configuration (Re 7500).
+
+    Rectangular open cavity with inflow on the left, free-slip top, and a
+    blowing/suction actuator on the leading edge whose velocity profile
+    follows Barbagallo et al (2009). The default observation is the
+    integral wall-normal shear stress at the trailing edge, and the
+    objective is the fluctuation kinetic energy relative to a stored base
+    flow ``qB`` (hence ``FUNCTIONS = ("q", "qB")``).
+    """
+
     DEFAULT_REYNOLDS = 7500
     DEFAULT_MESH = "fine"
     DEFAULT_DT = 1e-4
@@ -35,9 +45,25 @@ class Cavity(FlowConfig):
 
     @property
     def num_inputs(self) -> int:
+        """Number of control inputs: one (blowing/suction on the leading edge)."""
         return 1  # Blowing/suction on leading edge
 
     def configure_observations(self, obs_type=None, probe_obs_types={}) -> ObservationFunction:
+        """Select the observation function for the cavity.
+
+        Args:
+            obs_type (str, optional): Observation type. Defaults to
+                "stress_sensor". Probe-based types passed in
+                ``probe_obs_types`` are also supported.
+            probe_obs_types (dict, optional): Probe-based observation
+                functions provided by ``FlowConfig``.
+
+        Returns:
+            ObservationFunction: The selected observation function.
+
+        Raises:
+            ValueError: If ``obs_type`` is not a supported type.
+        """
         if obs_type is None:
             obs_type = "stress_sensor"  # Shear stress at trailing edge
 
@@ -52,6 +78,18 @@ class Cavity(FlowConfig):
         return supported_obs_types[obs_type]
 
     def init_bcs(self, function_spaces=None):
+        """Construct and apply the cavity boundary conditions.
+
+        Creates the inflow, freestream, no-slip wall, free-slip top, and
+        outflow conditions, plus the time-varying leading-edge actuation
+        boundary condition (stored in ``bcu_actuation`` as a
+        ``ScaledDirichletBC``), then applies the current control state.
+
+        Args:
+            function_spaces (optional): Pair of (velocity, pressure)
+                spaces to build conditions on; defaults to the subspaces
+                of the mixed space.
+        """
         if function_spaces is None:
             V, Q = self.function_spaces(mixed=True)
         else:
@@ -75,6 +113,11 @@ class Cavity(FlowConfig):
         self.set_control(self.control_state)
 
     def collect_bcu(self):
+        """List of velocity boundary conditions (inflow, freestream, walls, slip, actuation).
+
+        Returns:
+            list: All velocity ``DirichletBC`` objects for this flow.
+        """
         return [
             self.bcu_inflow,
             self.bcu_freestream,
@@ -84,9 +127,24 @@ class Cavity(FlowConfig):
         ]
 
     def collect_bcp(self):
+        """List of pressure boundary conditions.
+
+        Returns:
+            list: Pressure ``DirichletBC`` objects (zero pressure at the outlet).
+        """
         return [self.bcp_outflow]
 
     def linearize_bcs(self, function_spaces=None):
+        """Set boundary conditions to zero-amplitude for linearized problems.
+
+        Resets the controls to zero (which scales the actuation BC to
+        zero), reinitializes the boundary conditions, and sets the inflow
+        velocity to zero.
+
+        Args:
+            function_spaces (optional): Pair of (velocity, pressure)
+                spaces to rebuild the conditions on.
+        """
         self.reset_controls()
         self.init_bcs(function_spaces=function_spaces)
         self.bcu_inflow.set_value(fd.Constant((0, 0)))
@@ -100,6 +158,17 @@ class Cavity(FlowConfig):
         return (m,)
 
     def evaluate_objective(self, q=None, qB=None):
+        """Compute the fluctuation kinetic energy relative to a base flow.
+
+        Args:
+            q (fd.Function, optional): Flow state to evaluate; defaults to
+                the current state.
+            qB (fd.Function, optional): Base flow to subtract; defaults to
+                the stored base flow ``self.qB``.
+
+        Returns:
+            float: ``0.5 * ||u - uB||_L2^2`` of the velocity fields.
+        """
         if q is None:
             q = self.q
         if qB is None:
@@ -110,6 +179,19 @@ class Cavity(FlowConfig):
         return KE
 
     def render(self, mode="human", clim=None, levels=None, cmap="RdBu", **kwargs):
+        """Render the current vorticity field with matplotlib.
+
+        Args:
+            mode (str, optional): Rendering mode; only "human" plotting is
+                implemented.
+            clim (tuple, optional): (min, max) color limits for the
+                vorticity plot. Default (-10, 10).
+            levels (array, optional): Contour levels; defaults to 20
+                levels spanning ``clim``.
+            cmap (str, optional): Matplotlib colormap name. Default "RdBu".
+            **kwargs: Additional keyword arguments passed to
+                ``tricontourf``.
+        """
         _fig, ax = plt.subplots(1, 1, figsize=(6, 3))
         if clim is None:
             clim = (-10, 10)

--- a/hydrogym/firedrake/envs/cylinder/flow.py
+++ b/hydrogym/firedrake/envs/cylinder/flow.py
@@ -24,6 +24,15 @@ DEFAULT_PRES_PROBES = [
 
 
 class CylinderBase(FlowConfig):
+    """Base class for circular-cylinder flow configurations (Re 100).
+
+    Uniform inflow from the left with symmetry conditions top and bottom,
+    outflow on the right, and a single rotary/blowing-suction actuator on
+    the cylinder wall implemented as a ``ScaledDirichletBC`` driven by
+    ``cyl_velocity_field`` (subclasses define the velocity profile).
+    Default observations are the lift and drag coefficients.
+    """
+
     DEFAULT_REYNOLDS = 100
     DEFAULT_MESH = "medium"
     DEFAULT_DT = 1e-2
@@ -42,9 +51,25 @@ class CylinderBase(FlowConfig):
 
     @property
     def num_inputs(self) -> int:
+        """Number of control inputs: one (rotary control on the cylinder)."""
         return 1  # Rotary control
 
     def configure_observations(self, obs_type=None, probe_obs_types={}) -> ObservationFunction:
+        """Select the observation function for the cylinder.
+
+        Args:
+            obs_type (str, optional): Observation type. Defaults to
+                "lift_drag". Probe-based types passed in
+                ``probe_obs_types`` are also supported.
+            probe_obs_types (dict, optional): Probe-based observation
+                functions provided by ``FlowConfig``.
+
+        Returns:
+            ObservationFunction: The selected observation function.
+
+        Raises:
+            ValueError: If ``obs_type`` is not a supported type.
+        """
         if obs_type is None:
             obs_type = "lift_drag"
 
@@ -59,6 +84,18 @@ class CylinderBase(FlowConfig):
         return supported_obs_types[obs_type]
 
     def init_bcs(self, function_spaces=None):
+        """Construct and apply the cylinder boundary conditions.
+
+        Creates the inflow, freestream (symmetry), and outflow conditions,
+        plus the time-varying actuation boundary condition on the cylinder
+        wall (``ScaledDirichletBC`` with the subclass's
+        ``cyl_velocity_field``), then applies the current control state.
+
+        Args:
+            function_spaces (optional): Pair of (velocity, pressure)
+                spaces to build conditions on; defaults to the subspaces
+                of the mixed space.
+        """
         if function_spaces is None:
             V, Q = self.function_spaces(mixed=True)
         else:
@@ -79,13 +116,29 @@ class CylinderBase(FlowConfig):
 
     @property
     def cyl_velocity_field(self):
-        """Velocity vector for boundary condition"""
+        """Velocity vector for the actuation boundary condition on the cylinder.
+
+        Raises:
+            NotImplementedError: In the base class; subclasses must
+                override this.
+        """
         raise NotImplementedError
 
     def collect_bcu(self) -> list[fd.DirichletBC]:
+        """List of velocity boundary conditions (inflow, freestream, actuation).
+
+        Returns:
+            list[fd.DirichletBC]: All velocity ``DirichletBC`` objects.
+        """
         return [self.bcu_inflow, self.bcu_freestream, *self.bcu_actuation]
 
     def collect_bcp(self) -> list[fd.DirichletBC]:
+        """List of pressure boundary conditions.
+
+        Returns:
+            list[fd.DirichletBC]: Pressure ``DirichletBC`` objects (zero
+            pressure at the outlet).
+        """
         return [self.bcp_outflow]
 
     def compute_forces(self, q: fd.Function = None) -> tuple[float]:
@@ -142,6 +195,16 @@ class CylinderBase(FlowConfig):
         return fd.assemble((direction / self.Re * sqrt(du_dn_t[0] ** 2 + du_dn_t[1] ** 2)) * ds(self.CYLINDER))
 
     def linearize_bcs(self, function_spaces=None):
+        """Set boundary conditions to zero-amplitude for linearized problems.
+
+        Resets the controls to zero (which scales the actuation BC to
+        zero) and sets the inflow velocity and freestream condition to
+        zero.
+
+        Args:
+            function_spaces (optional): Pair of (velocity, pressure)
+                spaces to rebuild the conditions on.
+        """
         self.reset_controls(function_spaces=function_spaces)
         self.bcu_inflow.set_value(fd.Constant((0, 0)))
         self.bcu_freestream.set_value(fd.Constant(0.0))
@@ -152,6 +215,19 @@ class CylinderBase(FlowConfig):
         return CD
 
     def render(self, mode="human", clim=None, levels=None, cmap="RdBu", **kwargs):
+        """Render the current vorticity field with the cylinder overlaid.
+
+        Args:
+            mode (str, optional): Rendering mode; only "human" plotting is
+                implemented.
+            clim (tuple, optional): (min, max) color limits for the
+                vorticity plot. Default (-2, 2).
+            levels (array, optional): Contour levels; defaults to 10
+                levels spanning ``clim``.
+            cmap (str, optional): Matplotlib colormap name. Default "RdBu".
+            **kwargs: Additional keyword arguments passed to
+                ``tricontourf``.
+        """
         if clim is None:
             clim = (-2, 2)
         if levels is None:
@@ -172,11 +248,25 @@ class CylinderBase(FlowConfig):
 
 
 class RotaryCylinder(CylinderBase):
+    """Cylinder controlled by tangential (rotary) blowing on the wall.
+
+    The actuation boundary condition is a purely tangential velocity field
+    of constant magnitude around the cylinder, so scaling it with the
+    control input implements rotational forcing.
+    """
+
     MAX_CONTROL = 0.5 * np.pi
     DEFAULT_DT = 1e-2
 
     @property
     def cyl_velocity_field(self):
+        """Tangential velocity vector field around the cylinder surface.
+
+        Returns:
+            ufl.Tensor: Unit-magnitude tangential velocity
+            ``(-rad * sin(theta), rad * cos(theta))`` as a function of the
+            angle ``theta`` from the cylinder center.
+        """
         # Set up tangential boundaries to cylinder
         theta = atan2(ufl.real(self.y), ufl.real(self.x))  # Angle from origin
         self.rad = fd.Constant(RADIUS)
@@ -185,6 +275,13 @@ class RotaryCylinder(CylinderBase):
 
 
 class Cylinder(CylinderBase):
+    """Cylinder controlled by normal blowing/suction jets on the wall.
+
+    Two jets centered at the top and bottom of the cylinder follow
+    Rabault et al (2018), https://arxiv.org/abs/1808.07664, with a 10-degree
+    angular width each; the actuation BC is scaled by the control input.
+    """
+
     MAX_CONTROL = 0.1
     DEFAULT_DT = 1e-2
 
@@ -194,6 +291,11 @@ class Cylinder(CylinderBase):
 
         Blowing/suction actuation on the cylinder wall, following Rabault, et al (2018)
         https://arxiv.org/abs/1808.07664
+
+        Returns:
+            ufl.Tensor: Normal (radial) velocity field on the cylinder
+            wall, nonzero only within the jet widths around the top and
+            bottom of the cylinder.
         """
 
         # Set up tangential boundaries to cylinder

--- a/hydrogym/firedrake/envs/pinball/flow.py
+++ b/hydrogym/firedrake/envs/pinball/flow.py
@@ -13,6 +13,14 @@ from hydrogym.firedrake import FlowConfig, ObservationFunction, ScaledDirichletB
 
 
 class Pinball(FlowConfig):
+    """Flow over three cylinders in a triangular "pinball" arrangement (Re 30).
+
+    Uniform inflow with symmetry conditions top and bottom, and one rotary
+    (tangential) actuator per cylinder, so the number of control inputs is
+    three. The default observation is the six lift/drag coefficients (one
+    lift-drag pair per cylinder) and the objective is the total drag.
+    """
+
     DEFAULT_REYNOLDS = 30
     DEFAULT_MESH = "medium"
     DEFAULT_DT = 1e-2
@@ -33,6 +41,18 @@ class Pinball(FlowConfig):
     MESH_DIR = os.path.abspath(f"{__file__}/..")
 
     def init_bcs(self, function_spaces=None):
+        """Construct and apply the pinball boundary conditions.
+
+        Creates the inflow, freestream (symmetry), and outflow conditions,
+        plus one tangential (rotary) actuation boundary condition per
+        cylinder (each a ``ScaledDirichletBC`` scaled by the corresponding
+        control input), then applies the current control state.
+
+        Args:
+            function_spaces (optional): Pair of (velocity, pressure)
+                spaces to build conditions on; defaults to the subspaces
+                of the mixed space.
+        """
         if function_spaces is None:
             V, Q = self.function_spaces(mixed=True)
         else:
@@ -63,9 +83,25 @@ class Pinball(FlowConfig):
 
     @property
     def num_inputs(self) -> int:
+        """Number of control inputs: one rotary actuator per cylinder (three)."""
         return len(self.CYLINDER)
 
     def configure_observations(self, obs_type=None, probe_obs_types={}) -> ObservationFunction:
+        """Select the observation function for the pinball.
+
+        Args:
+            obs_type (str, optional): Observation type. Defaults to
+                "lift_drag". Probe-based types passed in
+                ``probe_obs_types`` are also supported.
+            probe_obs_types (dict, optional): Probe-based observation
+                functions provided by ``FlowConfig``.
+
+        Returns:
+            ObservationFunction: The selected observation function.
+
+        Raises:
+            ValueError: If ``obs_type`` is not a supported type.
+        """
         if obs_type is None:
             obs_type = "lift_drag"
 
@@ -84,12 +120,34 @@ class Pinball(FlowConfig):
         return supported_obs_types[obs_type]
 
     def collect_bcu(self) -> Iterable[fd.DirichletBC]:
+        """List of velocity boundary conditions (inflow, freestream, actuation).
+
+        Returns:
+            Iterable[fd.DirichletBC]: All velocity ``DirichletBC`` objects,
+            one actuation BC per cylinder.
+        """
         return [self.bcu_inflow, self.bcu_freestream, *self.bcu_actuation]
 
     def collect_bcp(self) -> Iterable[fd.DirichletBC]:
+        """List of pressure boundary conditions.
+
+        Returns:
+            Iterable[fd.DirichletBC]: Pressure ``DirichletBC`` objects
+            (zero pressure at the outlet).
+        """
         return [self.bcp_outflow]
 
     def compute_forces(self, q: fd.Function = None) -> Iterable[float]:
+        """Compute dimensionless lift/drag coefficients on each cylinder.
+
+        Args:
+            q (fd.Function, optional): Flow state to compute forces from;
+                defaults to the current state.
+
+        Returns:
+            Iterable[float]: Pair of lists ``(CL, CD)`` with one lift and
+            one drag value per cylinder, ordered as ``CYLINDER``.
+        """
         if q is None:
             q = self.q
         (u, p) = fd.split(q)
@@ -100,20 +158,64 @@ class Pinball(FlowConfig):
         return CL, CD
 
     def linearize_bcs(self, function_spaces=None):
+        """Set boundary conditions to zero-amplitude for linearized problems.
+
+        Resets the controls to zero (which scales the actuation BCs to
+        zero), reinitializes the boundary conditions, and sets the inflow
+        velocity and freestream condition to zero.
+
+        Args:
+            function_spaces (optional): Pair of (velocity, pressure)
+                spaces to rebuild the conditions on.
+        """
         self.reset_controls()
         self.init_bcs(function_spaces=function_spaces)
         self.bcu_inflow.set_value(fd.Constant((0, 0)))
         self.bcu_freestream.set_value(fd.Constant(0.0))
 
     def get_observations(self):
+        """Compute the current observation vector of lift/drag coefficients.
+
+        Returns:
+            list: Flattened list of lift coefficients followed by drag
+            coefficients, one entry per cylinder.
+        """
         CL, CD = self.compute_forces()
         return [*CL, *CD]
 
     def evaluate_objective(self, q=None):
+        """Compute the objective: the total drag over all cylinders.
+
+        Args:
+            q (fd.Function, optional): Flow state to evaluate; defaults to
+                the current state.
+
+        Returns:
+            float: Sum of the drag coefficients of all cylinders.
+        """
         CL, CD = self.compute_forces(q=q)
         return sum(CD)
 
     def render(self, mode="human", clim=None, levels=None, cmap="RdBu", **kwargs):
+        """Render the current vorticity field with the cylinder circles overlaid.
+
+        Args:
+            mode (str, optional): Rendering mode; only "human" plotting is
+                implemented.
+            clim (tuple, optional): (min, max) color limits for the
+                vorticity plot. Default (-2, 2).
+            levels (array, optional): Contour levels; defaults to 10
+                levels spanning ``clim``.
+            cmap (str, optional): Matplotlib colormap name. Default "RdBu".
+            **kwargs: Additional keyword arguments passed to
+                ``tricontourf``.
+
+        Raises:
+            AttributeError: As written this method reads the vorticity and
+                cylinder geometry from a ``self.flow`` attribute, which
+                ``FlowConfig`` does not define, so rendering a bare
+                ``Pinball`` instance will fail.
+        """
         if clim is None:
             clim = (-2, 2)
         if levels is None:

--- a/hydrogym/firedrake/envs/pinball/flow.py
+++ b/hydrogym/firedrake/envs/pinball/flow.py
@@ -106,6 +106,7 @@ class Pinball(FlowConfig):
             obs_type = "lift_drag"
 
         def _lift_drag(q):
+            """Observation payload: flattened lift coefficients followed by drag coefficients."""
             CL, CD = self.compute_forces(q=q)
             return [*CL, *CD]
 

--- a/hydrogym/firedrake/envs/step/flow.py
+++ b/hydrogym/firedrake/envs/step/flow.py
@@ -44,6 +44,18 @@ class Step(FlowConfig):
     MESH_DIR = os.path.abspath(f"{__file__}/..")
 
     def __init__(self, **kwargs):
+        """Initialize the step flow, including the random forcing parameters.
+
+        Args:
+            **kwargs: Forwarded to ``FlowConfig``, after removing:
+                - noise_amplitude (float): Amplitude of the white-noise
+                  forcing. Default 1.0.
+                - noise_time_constant (float): Time constant of the
+                  low-pass filter on the noise. Defaults to
+                  ``10 * TAU``.
+                - noise_seed (int, optional): Seed for the PCG64 random
+                  generator; None gives nondeterministic noise.
+        """
         # The random forcing is implemented as low-pass-filtered white noise
         # using the DampedActuator class as a filter.  The idea is to limit the
         # dependence of the spectral characteristics of the forcing on the time
@@ -57,14 +69,27 @@ class Step(FlowConfig):
 
     @property
     def num_inputs(self) -> int:
+        """Number of control inputs: one (blowing/suction on the step edge)."""
         return 1  # Blowing/suction on edge of step
 
     @property
     def nu(self):
+        """Kinematic viscosity ``0.5 / Re`` (half the base-class value).
+
+        Returns:
+            fd.Constant: The kinematic viscosity used by this flow.
+        """
         return fd.Constant(0.5 / ufl.real(self.Re))
 
     @property
     def body_force(self):
+        """Localized body force driven by the low-pass-filtered noise state.
+
+        Returns:
+            fd.Function: A vector function on the velocity space with a
+            Gaussian bump centered at (-1.0, 0.25), scaled by the current
+            ``noise_state``.
+        """
         delta = 0.1
         x0, y0 = -1.0, 0.25
         w = self.noise_state
@@ -76,6 +101,22 @@ class Step(FlowConfig):
         )
 
     def configure_observations(self, obs_type=None, probe_obs_types={}) -> ObservationFunction:
+        """Select the observation function for the step.
+
+        Args:
+            obs_type (str, optional): Observation type. Defaults to
+                "stress_sensor" (shear stress on the downstream wall).
+                Probe-based types passed in ``probe_obs_types`` are also
+                supported.
+            probe_obs_types (dict, optional): Probe-based observation
+                functions provided by ``FlowConfig``.
+
+        Returns:
+            ObservationFunction: The selected observation function.
+
+        Raises:
+            ValueError: If ``obs_type`` is not a supported type.
+        """
         if obs_type is None:
             obs_type = "stress_sensor"  # Shear stress on downstream wall
 
@@ -90,6 +131,18 @@ class Step(FlowConfig):
         return supported_obs_types[obs_type]
 
     def init_bcs(self, function_spaces=None):
+        """Construct and apply the step boundary conditions.
+
+        Creates a parabolic inflow profile, no-slip walls, and outflow
+        conditions, plus the time-varying actuation boundary condition on
+        the step edge (``ScaledDirichletBC``), then applies the current
+        control state.
+
+        Args:
+            function_spaces (optional): Pair of (velocity, pressure)
+                spaces to build conditions on; defaults to the subspaces
+                of the mixed space.
+        """
         if function_spaces is None:
             V, Q = self.function_spaces(mixed=True)
         else:
@@ -107,6 +160,23 @@ class Step(FlowConfig):
         self.set_control(self.control_state)
 
     def advance_time(self, dt, control=None):
+        """Advance the flow time by ``dt``, updating the stochastic forcing first.
+
+        Draws a white-noise sample (on rank zero of the MPI communicator,
+        then broadcast to all ranks), low-pass-filters the noise state
+        with the actuator-style filter (time constant ``noise_tau``), and
+        then calls the parent ``advance_time`` to update the flow state
+        and actuator.
+
+        Args:
+            dt (float): Time step size.
+            control (ArrayLike, optional): Control input(s) passed through
+                to the parent solver.
+
+        Returns:
+            list: The updated actuator (control) state, as returned by
+            ``FlowConfig.advance_time``.
+        """
         # Generate a noise sample
         comm = fd.COMM_WORLD
         w = np.zeros(1)
@@ -124,11 +194,26 @@ class Step(FlowConfig):
         return super().advance_time(dt, control)
 
     def linearize_bcs(self, function_spaces=None):
+        """Set boundary conditions to zero-amplitude for linearized problems.
+
+        Resets the controls to zero (which scales the actuation BC to
+        zero), reinitializes the boundary conditions, and sets the inflow
+        profile to zero.
+
+        Args:
+            function_spaces (optional): Pair of (velocity, pressure)
+                spaces to rebuild the conditions on.
+        """
         self.reset_controls()
         self.init_bcs(function_spaces=function_spaces)
         self.bcu_inflow.set_value(fd.Constant((0, 0)))
 
     def collect_bcu(self):
+        """List of velocity boundary conditions (inflow, walls, actuation).
+
+        Returns:
+            list: All velocity ``DirichletBC`` objects for this flow.
+        """
         return [
             self.bcu_inflow,
             self.bcu_noslip,
@@ -136,6 +221,11 @@ class Step(FlowConfig):
         ]
 
     def collect_bcp(self):
+        """List of pressure boundary conditions.
+
+        Returns:
+            list: Pressure ``DirichletBC`` objects (zero pressure at the outlet).
+        """
         return [self.bcp_outflow]
 
     def wall_stress_sensor(self, q=None):
@@ -147,6 +237,17 @@ class Step(FlowConfig):
         return (m,)
 
     def evaluate_objective(self, q=None, qB=None):
+        """Compute the fluctuation kinetic energy relative to a base flow.
+
+        Args:
+            q (fd.Function, optional): Flow state to evaluate; defaults to
+                the current state.
+            qB (fd.Function, optional): Base flow to subtract; defaults to
+                the stored base flow ``self.qB``.
+
+        Returns:
+            float: ``0.5 * ||u - uB||_L2^2`` of the velocity fields.
+        """
         if q is None:
             q = self.q
         if qB is None:
@@ -166,6 +267,22 @@ class Step(FlowConfig):
         xlim=None,
         **kwargs,
     ):
+        """Render the current vorticity field with matplotlib.
+
+        Args:
+            mode (str, optional): Rendering mode; only "human" plotting is
+                implemented.
+            axes (optional): Matplotlib axes to draw on; a new figure of
+                size (12, 2) is created if None.
+            clim (tuple, optional): (min, max) color limits for the
+                vorticity plot. Default (-5, 5).
+            levels (array, optional): Contour levels; defaults to 20
+                levels spanning ``clim``.
+            cmap (str, optional): Matplotlib colormap name. Default "RdBu".
+            xlim (list, optional): Horizontal axis limits. Default [-2, 10].
+            **kwargs: Additional keyword arguments passed to
+                ``tricontourf``.
+        """
         if clim is None:
             clim = (-5, 5)
         if xlim is None:

--- a/hydrogym/firedrake/flow.py
+++ b/hydrogym/firedrake/flow.py
@@ -1030,6 +1030,8 @@ class FlowConfig(PDEBase):
         F_im = self.residual((uB_im, pB_im), q_test=(v_im, s_im))
 
         def _inner(u, v):
+            """L2 inner product ``∫ u · v dx`` used to build the shift blocks
+            of the complex-valued eigenproblem's linear form."""
             return ufl.inner(u, v) * ufl.dx
 
         # Shift each block of the linear form appropriately

--- a/hydrogym/firedrake/flow.py
+++ b/hydrogym/firedrake/flow.py
@@ -19,7 +19,34 @@ interpolate = fd.interpolate
 
 
 class ScaledDirichletBC(fd.DirichletBC):
+    """Dirichlet boundary condition whose value can be rescaled in place.
+
+    Wraps a Firedrake ``DirichletBC`` and multiplies the prescribed value
+    ``g`` by an internal ``fd.Constant`` scale factor, so that the amplitude
+    of a boundary condition (e.g. actuation blowing/suction) can be changed
+    during a simulation without rebuilding the boundary condition. Call
+    ``set_scale`` to change the factor.
+
+    Attributes:
+        unscaled_function_arg: The original (unscaled) value ``g`` passed in.
+    """
+
     def __init__(self, V, g, sub_domain, method=None):
+        """Construct the scaled boundary condition.
+
+        Args:
+            V (fd.FunctionSpace): Function space the condition applies to.
+            g: Value to prescribe; may be a UFL expression. The stored
+                condition is ``self._scale * g``.
+            sub_domain: Mesh marker(s) of the boundary facets.
+            method: Boundary condition method, for compatibility with older
+                Firedrake versions whose ``DirichletBC`` still accepts it.
+                Newer versions ignore it.
+
+        Note:
+            Firedrake's constructor signature changed across versions, so
+            several calling conventions are tried in turn.
+        """
         self.unscaled_function_arg = g
         self._scale = fd.Constant(1.0)
 
@@ -38,18 +65,55 @@ class ScaledDirichletBC(fd.DirichletBC):
                 super().__init__(V, self._scale * g, sub_domain, method)
 
     def set_scale(self, c):
+        """Set the multiplicative factor applied to the prescribed value.
+
+        Args:
+            c: New scale factor; assigned to the internal ``fd.Constant``
+                so it can be updated without rebuilding the condition.
+        """
         self._scale.assign(c)
 
 
 class ObservationFunction(NamedTuple):
+    """Observation function paired with the number of values it produces.
+
+    Attributes:
+        func (Callable): Function mapping a flow state to a numpy array.
+        num_outputs (int): Size of the array returned by ``func``.
+    """
+
     func: Callable
     num_outputs: int
 
     def __call__(self, q: fd.Function) -> np.ndarray:
+        """Evaluate the wrapped observation function on a flow state.
+
+        Args:
+            q (fd.Function): Flow state to observe.
+
+        Returns:
+            np.ndarray: Observation values computed by ``func``.
+        """
         return self.func(q)
 
 
 class FlowConfig(PDEBase):
+    """Base class for incompressible Navier-Stokes flow configurations.
+
+    A ``FlowConfig`` owns the mesh, the mixed velocity/pressure function
+    space, the current state ``q``, the boundary conditions, and the
+    observation function used for RL feedback. Concrete environments
+    (cavity, cylinder, pinball, step) subclass this and provide at minimum
+    ``init_bcs``/``collect_bcu``/``collect_bcp``, ``linearize_bcs``, and
+    ``configure_observations``.
+
+    Checkpoints can be resolved automatically: if no ``restart`` is given,
+    an environment name is inferred from the class name, Reynolds number,
+    and mesh, and a matching checkpoint is fetched from the Hugging Face
+    Hub via the data manager (falling back to a zero initial condition if
+    none is found).
+    """
+
     DEFAULT_REYNOLDS = 1
     DEFAULT_VELOCITY_ORDER = 2  # Taylor-Hood elements
     DEFAULT_STABILIZATION = "none"
@@ -58,6 +122,38 @@ class FlowConfig(PDEBase):
     FUNCTIONS = ("q",)  # tuple of functions necessary for the flow
 
     def __init__(self, velocity_order=None, **config):
+        """Initialize the flow configuration.
+
+        Args:
+            velocity_order (int, optional): Polynomial order of the
+                Taylor-Hood velocity elements. Defaults to
+                ``DEFAULT_VELOCITY_ORDER``.
+            **config: Remaining configuration, consumed as keyword
+                arguments:
+                - Re (float): Reynolds number. Defaults to
+                  ``DEFAULT_REYNOLDS``.
+                - probes (list): (x, y) probe locations used by the probe
+                  observation types; validated against the mesh on
+                  initialization unless ``validate_probes`` is False.
+                - validate_probes (bool): Whether to check that ``probes``
+                  lie inside the mesh. Default True.
+                - observation_type (str): Key selecting the observation
+                  function, forwarded to ``configure_observations``.
+                - restart: Checkpoint to load: an explicit path, a
+                  Hugging Face Hub environment name, or a list of either.
+                  If None, a checkpoint is auto-inferred from the class
+                  name, Re, and mesh (and may be None if none is found).
+                - mesh (str): Mesh name (e.g. "medium"). Defaults to
+                  ``DEFAULT_MESH``.
+                - cache_dir, local_dir (str, optional): Custom cache and
+                  local fallback directories for checkpoint downloads.
+                - use_HF_data_manager (bool): Whether to resolve
+                  checkpoints via the Hugging Face Hub. Default True.
+                - hf_token (str, optional): Access token for private/gated
+                  Hub repos.
+                - hf_revision (str, optional): Hub revision to pin
+                  downloads to.
+        """
         self.Re = fd.Constant(ufl.real(config.pop("Re", self.DEFAULT_REYNOLDS)))
 
         if velocity_order is None:
@@ -293,9 +389,30 @@ class FlowConfig(PDEBase):
             return None
 
     def load_mesh(self, name: str) -> ufl.Mesh:
+        """Load a Gmsh mesh by name from ``MESH_DIR``.
+
+        Args:
+            name (str): Mesh name, e.g. "medium"; reads
+                ``{MESH_DIR}/{name}.msh``.
+
+        Returns:
+            ufl.Mesh: The loaded Firedrake mesh.
+        """
         return fd.Mesh(f"{self.MESH_DIR}/{name}.msh", name="mesh")
 
     def save_checkpoint(self, filename: str, write_mesh=True, idx=None):
+        """Save the current state and actuator states to a Firedrake checkpoint.
+
+        Every function named in ``FUNCTIONS`` is written, along with the
+        state of each actuator as a file-level attribute "act_state".
+
+        Args:
+            filename (str): Path of the checkpoint file to write.
+            write_mesh (bool, optional): Whether to also save the mesh.
+                Default True.
+            idx (int, optional): Time index to attach to the saved
+                functions, if any.
+        """
         with fd.CheckpointFile(filename, "w") as chk:
             if write_mesh:
                 chk.save_mesh(self.mesh)  # optional
@@ -306,6 +423,22 @@ class FlowConfig(PDEBase):
             chk.set_attr("/", "act_state", act_state)
 
     def load_checkpoint(self, filename: str, idx=None, read_mesh=True):
+        """Load the flow state (and actuator states) from a checkpoint.
+
+        Each function named in ``FUNCTIONS`` is read back onto the current
+        function space; if the checkpoint was written on a different
+        element, the field is projected onto the current space instead of
+        being assigned directly. Missing functions default to zero with a
+        warning. If a stored "act_state" attribute is present, it is used
+        to restore each actuator's state.
+
+        Args:
+            filename (str): Path of the checkpoint file to read.
+            idx (int, optional): Time index of the saved functions to load.
+            read_mesh (bool, optional): Whether to load the mesh from the
+                file and reinitialize state. Default True; if False, the
+                current mesh must already be initialized.
+        """
         with fd.CheckpointFile(filename, "r") as chk:
             if read_mesh:
                 self.mesh = chk.load_mesh("mesh")
@@ -340,17 +473,57 @@ class FlowConfig(PDEBase):
         self.split_solution()  # Reset functions so self.u, self.p point to the new solution
 
     def configure_observations(self, obs_type=None, probe_obs_types={}) -> ObservationFunction:
+        """Select the observation function for this flow.
+
+        Subclasses should build a mapping of available observation types
+        (including the probe-based ones passed in ``probe_obs_types``) and
+        return the one named by ``obs_type``, raising ``ValueError`` for an
+        unknown type.
+
+        Args:
+            obs_type (str, optional): Name of the desired observation type.
+                Defaults to a subclass-specific choice.
+            probe_obs_types (dict, optional): Mapping of probe-based
+                observation type names to ``ObservationFunction`` objects,
+                as constructed by ``FlowConfig.__init__``.
+
+        Returns:
+            ObservationFunction: The selected observation function.
+
+        Raises:
+            NotImplementedError: In the base class; subclasses must
+                override this.
+        """
         raise NotImplementedError
 
     def get_observations(self) -> np.ndarray:
+        """Compute the current observation vector.
+
+        Returns:
+            np.ndarray: Output of the configured observation function
+            evaluated on the current state.
+        """
         return self.obs_fun(self.q)
 
     @property
     def num_outputs(self) -> int:
-        # This may be lift/drag, a stress "sensor", or a set of probe locations
+        """Number of values in the observation vector.
+
+        This may be lift/drag, a stress "sensor", or a set of probe
+        locations, depending on the configured observation type.
+        """
         return self.obs_fun.num_outputs
 
     def initialize_state(self):
+        """Create the function spaces and state functions on the current mesh.
+
+        Sets up the Taylor-Hood mixed space (continuous vector-valued
+        velocity of order ``velocity_order`` and continuous piecewise-linear
+        pressure), allocates one ``fd.Function`` per name in ``FUNCTIONS``,
+        breaks out the velocity and pressure subfunctions, allocates the
+        internal vorticity field, and validates any configured probe
+        locations.
+        """
         # Set up UFL objects referring to the mesh
         self.n = fd.FacetNormal(self.mesh)
         self.x, self.y = fd.SpatialCoordinate(self.mesh)
@@ -411,9 +584,16 @@ class FlowConfig(PDEBase):
 
     @property
     def nu(self):
+        """Kinematic viscosity ``1 / Re`` as a Firedrake Constant."""
         return fd.Constant(1 / ufl.real(self.Re))
 
     def split_solution(self):
+        """Break the mixed state out into velocity and pressure fields.
+
+        Assigns ``self.u`` and ``self.p`` to the subfunctions of ``self.q``
+        and renames them to "u" and "p", so that fields saved under those
+        names stay consistent after loading or reinitializing state.
+        """
         self.u, self.p = self.q.subfunctions
         self.u.rename("u")
         self.p.rename("p")
@@ -510,6 +690,13 @@ class FlowConfig(PDEBase):
 
     @property
     def body_force(self):
+        """Volumetric body force term (zero by default).
+
+        Returns:
+            fd.Function: A vector function on the velocity space, assigned
+            to zero. Subclasses may override this to return a nontrivial
+            forcing field.
+        """
         return fd.Function(self.velocity_space).assign(fd.Constant((0.0, 0.0)))
 
     def linearize_bcs(self):
@@ -669,6 +856,35 @@ class FlowConfig(PDEBase):
         return vort_vom.dat.data_ro
 
     def linearize(self, qB=None, adjoint=False, sigma=0.0, inverse=False, solver_parameters=None):
+        """Return a linear operator for the Navier-Stokes equations about a base flow.
+
+        By default returns the Jacobian operator ``dF/dq`` evaluated at the
+        base state ``qB``. With ``inverse=True``, returns an operator that
+        solves the mass-matrix pencil ``(J - sigma * M) @ v1 = M @ v0``,
+        shifted by the (possibly complex) ``sigma``; complex shifts are
+        handled as a real block system with twice the degrees of freedom.
+
+        Args:
+            qB (fd.Function, optional): Base state to linearize about.
+                Defaults to the current state.
+            adjoint (bool, optional): Whether to return the transpose
+                (adjoint) of the operator. Default False.
+            sigma (complex, optional): Spectral shift. Default 0.0; must be
+                zero unless ``inverse=True``.
+            inverse (bool, optional): Whether to return a shift-inverse
+                (solve) operator instead of the Jacobian itself. Default
+                False.
+            solver_parameters (dict, optional): PETSc solver parameters for
+                the inverse operators.
+
+        Returns:
+            DirectOperator or InverseOperator: The requested linear
+            operator (transposed if ``adjoint=True``).
+
+        Raises:
+            ValueError: If a nonzero ``sigma`` is given with
+                ``inverse=False``.
+        """
         if sigma != 0.0 and not inverse:
             raise ValueError("Must use `inverse=True` with spectral shift.")
 

--- a/hydrogym/firedrake/solvers/base.py
+++ b/hydrogym/firedrake/solvers/base.py
@@ -10,12 +10,32 @@ __all__ = ["NewtonSolver"]
 
 
 class NewtonSolver:
+    """Newton solver for the steady-state Navier-Stokes equations.
+
+    Assembles the nonlinear steady residual of ``flow.steady_form`` (with
+    optional SUPG/GLS-type stabilization) and solves the resulting
+    nonlinear variational problem with Firedrake's Newton solver.
+    """
+
     def __init__(
         self,
         flow: FlowConfig,
         stabilization: str = "none",
         solver_parameters: dict = {},
     ):
+        """Configure the steady solver.
+
+        Args:
+            flow (FlowConfig): Flow configuration defining the mesh,
+                function spaces, and boundary conditions.
+            stabilization (str, optional): Stabilization method, one of
+                the keys of ``ns_stabilization``. Default "none".
+            solver_parameters (dict, optional): Parameters passed through
+                to ``fd.NonlinearVariationalSolver``.
+
+        Raises:
+            ValueError: If ``stabilization`` is not a recognized type.
+        """
         self.flow = flow
         self.solver_parameters = solver_parameters
 
@@ -43,6 +63,21 @@ class NewtonSolver:
         return q.copy(deepcopy=True)
 
     def steady_form(self, q: fd.Function, q_test=None):
+        """Assemble the nonlinear steady-state Navier-Stokes variational form.
+
+        Builds ``F(u, p; v, s)`` with the sign convention used for
+        steady solves (advection and stress terms positive), plus any
+        stabilization terms. This differs from ``FlowConfig.residual``,
+        whose signs are written for the transient problem.
+
+        Args:
+            q (fd.Function): Mixed trial state (u, p).
+            q_test (optional): Pair of test functions (v, s); defaults to
+                the test functions of the flow's mixed space.
+
+        Returns:
+            ufl.Form: The nonlinear residual form.
+        """
         (u, p) = q
         if q_test is None:
             (v, s) = fd.TestFunctions(self.flow.mixed_space)
@@ -71,7 +106,31 @@ class NewtonSolver:
 
 
 class NavierStokesTransientSolver(TransientSolver):
+    """Base class for transient Navier-Stokes solvers.
+
+    Extends ``TransientSolver`` with a hook-based reset: subclasses
+    allocate their fields and variational forms in
+    ``initialize_functions`` and ``initialize_operators``, both of which
+    are invoked on construction and on every ``reset``.
+    """
+
     def __init__(self, flow: FlowConfig, dt: float = None, debug: bool = False):
+        """Initialize the transient solver.
+
+        Args:
+            flow (FlowConfig): Flow configuration to advance in time.
+            dt (float, optional): Time step. Defaults to ``TransientSolver``'s
+                handling (typically the flow's ``DEFAULT_DT``).
+            debug (bool, optional): Whether to enable debug output.
+                Default False.
+
+        Note:
+            This class previously accepted ``eta``/``max_noise_iter``/
+            ``noise_cutoff`` for a random white-noise body forcing, but the
+            forcing was removed upstream (a067781, 2024-03) and those
+            kwargs were silently ignored ever since; they were removed in
+            this repo's audit Task 2.3.
+        """
         # NOTE: this class previously accepted eta/max_noise_iter/noise_cutoff
         # for a random white-noise body forcing, but the forcing itself was
         # removed upstream in a067781 ("Clean up old forcing code", 2024-03)
@@ -82,6 +141,11 @@ class NavierStokesTransientSolver(TransientSolver):
         self.reset()
 
     def reset(self):
+        """Reset the solver to its initial condition and rebuild state.
+
+        Calls the parent reset, then re-runs ``initialize_functions`` and
+        ``initialize_operators``.
+        """
         super().reset()
 
         self.initialize_functions()
@@ -89,7 +153,17 @@ class NavierStokesTransientSolver(TransientSolver):
         self.initialize_operators()
 
     def initialize_functions(self):
+        """Allocate solver-specific state fields.
+
+        No-op in the base class; subclasses should override this to create
+        the functions they need.
+        """
         pass
 
     def initialize_operators(self):
+        """Allocate solver-specific variational forms and operators.
+
+        No-op in the base class; subclasses should override this to set up
+        their forms/operators.
+        """
         pass

--- a/hydrogym/firedrake/solvers/bdf_ext.py
+++ b/hydrogym/firedrake/solvers/bdf_ext.py
@@ -24,6 +24,31 @@ _beta_EXT = [
 
 
 class SemiImplicitBDF(NavierStokesTransientSolver):
+    """Semi-implicit BDF transient solver for the incompressible Navier-Stokes equations.
+
+    Uses a backward-differentiation formula of order ``k`` for the time
+    derivative (treated implicitly, together with the viscous and pressure
+    terms) and a k-th-order extrapolation of the velocity for the convective
+    term, which is thereby treated explicitly. The result is a sequence of
+    linear variational problems, one per BDF order, solved each timestep with
+    Firedrake's ``LinearVariationalSolver``.
+
+    For ``k > 1`` the first ``k - 1`` timesteps are taken with lower-order
+    startup solvers (order 1 .. k-1, each with a matching extrapolation),
+    since the full-order scheme needs ``k`` previous solutions.
+
+    Attributes:
+        k: Order of the BDF/extrapolation scheme (1, 2, or 3).
+        ksp_rtol: Relative tolerance for the Krylov solver.
+        custom_solver_parameters: User-supplied PETSc solver parameters,
+            overriding the built-in defaults (see ``_make_petsc_solver``).
+        stabilization: Name of the stabilization scheme (a key of
+            :data:`~hydrogym.firedrake.solvers.stabilization.ns_stabilization`);
+            ``"default"`` resolves to ``flow.DEFAULT_STABILIZATION``.
+        u_prev: List of the ``k`` most recent velocity solutions (oldest
+            first) used to build the BDF and extrapolation combinations.
+    """
+
     def __init__(
         self,
         flow: FlowConfig,
@@ -34,6 +59,25 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
         solver_parameters: dict = None,
         **kwargs,
     ):
+        """Initialize the solver and build the BDF/startup operators.
+
+        Args:
+            flow: Flow configuration (mesh, mixed space, BCs, forcing).
+            dt: Timestep size.
+            order: Order of the BDF/extrapolation scheme (1-3).
+            stabilization: Stabilization type; ``"default"`` resolves to the
+                flow's ``DEFAULT_STABILIZATION``. See ``ns_stabilization`` for
+                the available keys (e.g. "none", "supg", "gls", and their
+                "linearized_" variants).
+            rtol: Relative tolerance for the Krylov (KSP) solver.
+            solver_parameters: Optional PETSc solver parameters replacing the
+                built-in defaults chosen in ``_make_petsc_solver``.
+            **kwargs: Forwarded to
+                :class:`~hydrogym.firedrake.solvers.base.NavierStokesTransientSolver`.
+
+        Raises:
+            ValueError: If ``stabilization`` is not a recognized type.
+        """
         self.k = order  # Order of the BDF/EXT scheme
         self.ksp_rtol = rtol  # Krylov solver tolerance
         self.custom_solver_parameters = solver_parameters  # Custom solver parameters
@@ -52,6 +96,13 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
         self.reset()
 
     def initialize_functions(self):
+        """Allocate trial/test functions and the BDF history of previous solutions.
+
+        Sets ``self.q_trial``/``self.q_test`` (velocity-pressure pairs on the
+        mixed space), aliases the body force ``self.f`` from the flow
+        configuration, and creates ``k`` copies of the current velocity in
+        ``self.u_prev`` so the first (startup) steps have valid history.
+        """
         flow = self.flow
         self.f = flow.body_force
 
@@ -73,6 +124,23 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
             u.assign(flow.q.subfunctions[0])
 
     def _make_petsc_solver(self, weak_form):
+        """Wrap a weak form in a Firedrake linear variational problem and PETSc solver.
+
+        The problem is defined on the flow's current state ``self.flow.q``
+        with the flow's boundary conditions applied.
+
+        Args:
+            weak_form: UFL form (zero if written ``lhs - rhs = 0``) for the
+                order-``k`` BDF step.
+
+        Returns:
+            fd.LinearVariationalSolver: Solver with either the user-supplied
+            parameters or built-in defaults: a Schur-complement fieldsplit
+            preconditioner for the unstabilized saddle-point system, monolithic
+            hypre AMG for SUPG-type stabilization, and a direct LU/MUMPS solve
+            for GLS-type stabilization (which is incompatible with the Schur
+            complement approach).
+        """
         # Construct variational problem and PETSc solver
         q = self.flow.q
         a = lhs(weak_form)
@@ -133,6 +201,20 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
         return petsc_solver
 
     def _stabilize_weak_form(self, weak_form, u_t, wind, f=None):
+        """Append the configured stabilization terms (SUPG, GLS, etc.) to a weak form.
+
+        Args:
+            weak_form: The unstabilized UFL weak form.
+            u_t: UFL expression for the BDF estimate of the time derivative.
+            wind: Velocity field used as the "wind" in the convective and
+                stabilization terms (the extrapolated velocity, or the base
+                flow for the linearized solvers).
+            f: Body forcing entering the residual-based stabilization terms.
+
+        Returns:
+            The weak form with the stabilization term added (unchanged for
+            the "none" stabilization types).
+        """
         # Stabilization (SUPG, GLS, etc.)
         stab = self.StabilizationType(
             self.flow,
@@ -146,6 +228,25 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
         return stab.stabilize(weak_form)
 
     def _make_order_k_solver(self, k):
+        """Build the (order-``k`` BDF + order-``k`` extrapolation) solver.
+
+        Assembles the semi-implicit weak form
+
+            ``(alpha_k u - sum beta_BDF u_n) / dt + w . grad(u) + sigma(u,p) : eps(v)
+            + div(u) s - f . v``
+
+        where ``w`` is the order-``k`` extrapolation of the previous
+        velocities (the explicit convective velocity) and ``alpha_k``/``beta_BDF``
+        are the BDF-``k`` coefficients, then adds stabilization and wraps the
+        form in a PETSc solver.
+
+        Args:
+            k: BDF order to build (``1..self.k``); orders below ``self.k``
+                are the startup schemes used for the first timesteps.
+
+        Returns:
+            fd.LinearVariationalSolver: Solver for the order-``k`` step.
+        """
         # Setup functions and spaces
         flow = self.flow
         h = fd.Constant(self.dt)
@@ -174,6 +275,12 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
         return self._make_petsc_solver(weak_form)
 
     def initialize_operators(self):
+        """Build the main order-``k`` solver and the lower-order startup solvers.
+
+        Initializes the flow's boundary conditions first, then constructs the
+        full-order BDF solver and, if ``k > 1``, one solver per order
+        ``1 .. k-1`` for the startup timesteps (``self.startup_solvers``).
+        """
         self.flow.init_bcs()
         self.petsc_solver = self._make_order_k_solver(self.k)
 
@@ -184,6 +291,23 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
                 self.startup_solvers.append(self._make_order_k_solver(i + 1))
 
     def step(self, iter, control=None):
+        """Advance the flow by one timestep.
+
+        The flow's time is advanced (which also applies any actuation
+        scaling), the appropriate linear problem is solved — the full-order
+        BDF solver once ``iter`` exceeds ``k - 1``, otherwise the matching
+        lower-order startup solver — and the velocity history is shifted so
+        the newest solution enters ``u_prev[0]``.
+
+        Args:
+            iter: Timestep index within the solve (0-based); the first
+                ``k - 1`` iterations use the startup solvers.
+            control: Optional actuation value(s) forwarded to
+                ``flow.advance_time`` to scale the actuation BCs.
+
+        Returns:
+            FlowConfig: The updated flow configuration.
+        """
         # Update the time of the flow
         # TODO: Test with actuation
         bc_scale = self.flow.advance_time(self.dt, control)
@@ -205,7 +329,37 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
 
 
 class LinearizedBDF(SemiImplicitBDF):
+    """Semi-implicit BDF solver for the Navier-Stokes equations linearized about a base flow.
+
+    Instead of the full convective term, solves the linearized form
+
+        ``du/dt + uB . grad(u) + u . grad(uB) - div(sigma(u,p)) = f``
+
+    around the base flow ``qB`` supplied at construction, with the flow's
+    boundary conditions linearized (``flow.linearize_bcs()``) and the
+    base-flow velocity ``uB`` acting as the "wind" in the stabilization
+    terms. Intended for adjoint/transient-growth-type analyses about a known
+    (typically steady) state.
+
+    Attributes:
+        qB: Base flow (mixed velocity-pressure ``fd.Function``) to
+            linearize about.
+    """
+
     def __init__(self, *args, qB: fd.Function, **kwargs):
+        """Initialize the linearized solver.
+
+        Args:
+            *args: Positional arguments forwarded to
+                :class:`SemiImplicitBDF` (``flow``, ``dt``, ...).
+            qB: Base flow (mixed velocity-pressure function) to linearize
+                the equations about.
+            **kwargs: Keyword arguments forwarded to :class:`SemiImplicitBDF`.
+                ``stabilization`` defaults to ``"none"`` (resolved to
+                ``"linearized_none"``) rather than the unlinearized default;
+                a plain name (e.g. ``"supg"``) is automatically prefixed with
+                ``"linearized_"``.
+        """
         self.qB = qB
         stabilization = kwargs.pop("stabilization", "none").split("_")
         if stabilization[0] != "linearized":
@@ -214,6 +368,21 @@ class LinearizedBDF(SemiImplicitBDF):
         super().__init__(*args, stabilization=stabilization, **kwargs)
 
     def _make_order_k_solver(self, k):
+        """Build the order-``k`` solver for the base-flow-linearized weak form.
+
+        Like :meth:`SemiImplicitBDF._make_order_k_solver`, but the convective
+        terms are the linearized pair ``uB . grad(u) + u . grad(uB)``, the
+        flow's boundary conditions are linearized (``flow.linearize_bcs()``),
+        and the base-flow velocity ``uB`` is used as the wind in the
+        stabilization terms. The base-flow forcing contributions on the RHS
+        vanish for a steady base flow and are folded into ``self.f``.
+
+        Args:
+            k: BDF order to build (``1..self.k``).
+
+        Returns:
+            fd.LinearVariationalSolver: Solver for the order-``k`` step.
+        """
         # Setup functions and spaces
         flow = self.flow
         sigma, epsilon = flow.sigma, flow.epsilon

--- a/hydrogym/firedrake/solvers/stabilization.py
+++ b/hydrogym/firedrake/solvers/stabilization.py
@@ -15,6 +15,28 @@ __all__ = ["SUPG", "GLS", "ns_stabilization"]
 
 @dataclasses.dataclass
 class NavierStokesStabilization(metaclass=abc.ABCMeta):
+    """Base class (and "no stabilization" implementation) for Navier-Stokes stabilization schemes.
+
+    Bundles everything the residual-based stabilization terms need from the
+    calling solver; subclasses build the actual UFL stabilization forms in
+    :meth:`stabilize`. This base class implements the identity map, i.e. the
+    unstabilized Galerkin formulation (the ``"none"``/``"linearized_none"``
+    options in ``ns_stabilization``).
+
+    Attributes:
+        flow: Flow configuration (mesh, viscosity, stress/strain operators).
+        q_trial: ``(u, p)`` pair of trial functions on the mixed space.
+        q_test: ``(v, s)`` pair of test functions on the mixed space.
+        wind: Velocity field used as the convective wind (the extrapolated
+            velocity for the nonlinear solvers, or the base flow for the
+            linearized ones).
+        dt: Timestep (float or ``fd.Constant``); enters the stabilization
+            parameter ``tau_M`` when given.
+        u_t: UFL expression for the time derivative estimate (the BDF term),
+            included in the strong-form residual when given.
+        f: Body forcing, subtracted from the strong-form residual when given.
+    """
+
     flow: FlowConfig
     q_trial: tuple[fd.Function, fd.Function]
     q_test: tuple[fd.Function, fd.Function]
@@ -24,17 +46,48 @@ class NavierStokesStabilization(metaclass=abc.ABCMeta):
     f: fd.Function = None
 
     def stabilize(self, weak_form):
+        """Return the weak form unchanged (no stabilization terms).
+
+        Args:
+            weak_form: The unstabilized UFL weak form.
+
+        Returns:
+            The same weak form, unmodified.
+        """
         # By default, no stabilization
         return weak_form
 
 
 class UpwindNSStabilization(NavierStokesStabilization):
+    """Residual-based upwind stabilization for the (unlinearized) Navier-Stokes equations.
+
+    Shared machinery for SUPG and GLS: computes the strong-form momentum
+    residual ``Lu`` with the given wind, the stabilization parameters
+    ``tau_M``/``tau_C`` from the element size, wind magnitude, viscosity and
+    (optionally) timestep, and adds ``tau_M <Lu, Lv>`` plus a least-squares
+    incompressibility (LSIC) term ``tau_C <div u, div v>`` to the weak form.
+    Subclasses define ``Lv``, the residual operator applied to the test
+    functions.
+
+    Attributes (inherited from :class:`NavierStokesStabilization`) supply the
+    trial/test functions, wind, timestep, time derivative and forcing.
+    """
+
     @property
     def h(self):
+        """Mesh cell size (UFL ``CellSize``), the length scale in ``tau_M``."""
         return fd.CellSize(self.flow.mesh)
 
     @property
     def Lu(self):
+        """Strong-form momentum residual of the trial functions.
+
+        ``w . grad(u) - div(sigma(u,p))``, plus the time-derivative estimate
+        ``u_t`` and minus the forcing ``f`` when those are supplied.
+
+        Returns:
+            UFL expression for ``Lu`` (the momentum residual).
+        """
         (u, p) = self.q_trial
 
         w = self.wind
@@ -52,11 +105,27 @@ class UpwindNSStabilization(NavierStokesStabilization):
 
     @abc.abstractproperty
     def Lv(self):
+        """Residual operator applied to the test functions (subclass-specific).
+
+        Returns:
+            UFL expression for ``Lv``, paired with ``Lu`` in the
+            stabilization inner product.
+        """
         # Test function form for the stabilization term
         pass
 
     @property
     def tau_M(self):
+        """Stabilization parameter for the momentum residual.
+
+        ``tau_M = (4|w|^2/h^2 + 9 (4 nu / h^2)^2 [+ 4/dt^2])^(-1/2)``, i.e.
+        the inverse squared "elemental" advective/diffusive/temporal rates.
+        Based on:
+        https://github.com/florianwechsung/alfi/blob/master/alfi/stabilisation.py
+
+        Returns:
+            UFL expression for ``tau_M``.
+        """
         # Stabilization constant for momentum residual
         #
         # Based on:
@@ -75,37 +144,88 @@ class UpwindNSStabilization(NavierStokesStabilization):
 
     @property
     def tau_C(self):
+        """Stabilization parameter for the continuity residual, ``h^2 / tau_M``.
+
+        Returns:
+            UFL expression for ``tau_C``.
+        """
         # Stabilization constant for continuity residual
         h = self.h
         return h**2 / self.tau_M
 
     @property
     def momentum_stabilization(self):
+        """Momentum stabilization term ``tau_M <Lu, Lv> dx``.
+
+        Returns:
+            UFL form to be added to the weak form.
+        """
         return self.tau_M * inner(self.Lu, self.Lv) * dx
 
     @property
     def lsic_stabilization(self):
+        """Least-squares incompressibility (LSIC) term ``tau_C <div u, div v> dx``.
+
+        Returns:
+            UFL form to be added to the weak form.
+        """
         (u, _) = self.q_trial
         (v, _) = self.q_test
         return self.tau_C * inner(div(u), div(v)) * dx
 
     def stabilize(self, weak_form):
+        """Add the momentum and LSIC stabilization terms to a weak form.
+
+        Args:
+            weak_form: The unstabilized UFL weak form.
+
+        Returns:
+            The weak form with ``momentum_stabilization`` and
+            ``lsic_stabilization`` appended.
+        """
         weak_form += self.momentum_stabilization
         weak_form += self.lsic_stabilization
         return weak_form
 
 
 class SUPG(UpwindNSStabilization):
+    """Streamline-Upwind/Petrov-Galerkin stabilization.
+
+    Uses only the streamline derivative ``w . grad(v)`` of the velocity test
+    function as the residual operator ``Lv``, so the stabilization acts
+    along the flow direction.
+    """
+
     @property
     def Lv(self):
+        """Streamline derivative of the velocity test function, ``w . grad(v)``.
+
+        Returns:
+            UFL expression for ``Lv``.
+        """
         (v, _) = self.q_test
         w = self.wind
         return dot(w, nabla_grad(v))
 
 
 class GLS(UpwindNSStabilization):
+    """Galerkin least-squares stabilization.
+
+    Uses the full momentum operator applied to the test functions,
+    ``Lv = w . grad(v) - div(sigma(v, s))``, so the least-squares term
+    minimizes the complete momentum residual (not just its streamline
+    component, as SUPG does).
+    """
+
     @property
     def Lv(self):
+        """Full momentum operator applied to the test functions.
+
+        ``w . grad(v) - div(sigma(v, s))``.
+
+        Returns:
+            UFL expression for ``Lv``.
+        """
         (v, s) = self.q_test
         w = self.wind
         sigma = self.flow.sigma
@@ -113,8 +233,25 @@ class GLS(UpwindNSStabilization):
 
 
 class LinearizedNSStabilization(UpwindNSStabilization):
+    """Residual-based stabilization for the Navier-Stokes equations linearized about a base flow.
+
+    Identical machinery to :class:`UpwindNSStabilization`, except the
+    strong-form momentum residual ``Lu`` uses the linearized convective
+    operator ``uB . grad(u) + u . grad(uB)``, where the base flow ``uB`` is
+    supplied as the ``wind``.
+    """
+
     @property
     def Lu(self):
+        """Strong-form momentum residual of the linearized operator.
+
+        ``uB . grad(u) + u . grad(uB) - div(sigma(u,p))``, plus the
+        time-derivative estimate ``u_t`` and minus the forcing ``f`` when
+        those are supplied.
+
+        Returns:
+            UFL expression for the linearized momentum residual ``Lu``.
+        """
         (u, p) = self.q_trial
 
         uB = self.wind
@@ -132,16 +269,42 @@ class LinearizedNSStabilization(UpwindNSStabilization):
 
 
 class LinearizedSUPG(LinearizedNSStabilization):
+    """Streamline-upwind stabilization of the base-flow-linearized equations.
+
+    The SUPG residual operator about the base flow: both linearized
+    convective terms applied to the test function.
+    """
+
     @property
     def Lv(self):
+        """Linearized streamline derivative of the test function.
+
+        ``uB . grad(v) + v . grad(uB)``.
+
+        Returns:
+            UFL expression for ``Lv``.
+        """
         (v, _) = self.q_test
         uB = self.wind
         return dot(uB, nabla_grad(v)) + dot(v, nabla_grad(uB))
 
 
 class LinearizedGLS(LinearizedNSStabilization):
+    """Galerkin least-squares stabilization of the base-flow-linearized equations.
+
+    The full linearized momentum operator applied to the test functions
+    (linearized convective terms plus the viscous/pressure operator).
+    """
+
     @property
     def Lv(self):
+        """Full linearized momentum operator applied to the test functions.
+
+        ``uB . grad(v) + v . grad(uB) - div(sigma(v, s))``.
+
+        Returns:
+            UFL expression for ``Lv``.
+        """
         (v, s) = self.q_test
         uB = self.wind
         sigma = self.flow.sigma

--- a/hydrogym/jax/env_core.py
+++ b/hydrogym/jax/env_core.py
@@ -429,6 +429,15 @@ class JAXFlowEnvBase(environment.Environment[EnvState, EnvParams]):
         )
 
     def _clip_action(self, action: chex.Array, params: EnvParams) -> chex.Array:
+        """Clip an action to the environment's action space bounds.
+
+        Args:
+            action: Raw (unclipped) action array.
+            params: Environment parameters supplying ``min_action``/``max_action``.
+
+        Returns:
+            The action element-wise clipped into ``[min_action, max_action]``.
+        """
         return jnp.clip(action, params.min_action, params.max_action)
 
     def is_terminal(self, state: EnvState, params: EnvParams) -> jnp.ndarray:
@@ -519,6 +528,7 @@ class GymnaxWrapper(object):
 
     # provide proxy access to regular attributes of wrapped object
     def __getattr__(self, name):
+        """Proxy attribute access through to the wrapped environment."""
         return getattr(self._env, name)
 
 

--- a/hydrogym/jax/env_core.py
+++ b/hydrogym/jax/env_core.py
@@ -26,6 +26,13 @@ from hydrogym.hf_env_mixin import ConfigError, HFEnvConfigMixin
 
 
 class EnvParams(environment.EnvParams):
+    """Gymnax environment parameters extended with the environment config dictionary.
+
+    Attributes:
+        config: Environment configuration (grid sizes, control bounds, etc.)
+            as loaded from the environment's configuration file.
+    """
+
     config: dict
 
 
@@ -282,15 +289,66 @@ class JAXFlowEnv(HFEnvConfigMixin, environment.Environment[EnvState, EnvParams])
         self.cfg = omegaconf.OmegaConf.load(self.configuration_file)
 
     def reset_env(self, key: chex.PRNGKey, params: EnvParams) -> Tuple[chex.Array, EnvState]:
+        """Reset the environment to its initial condition.
+
+        Args:
+            key: PRNG key for stochastic resets.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, state)`` of the initial observation and state.
+
+        Raises:
+            NotImplementedError: Always; subclasses define the actual reset.
+        """
         raise NotImplementedError
 
     def get_obs(self, state: EnvState, params: EnvParams, key=None) -> chex.Array:
+        """Compute the observation from the current environment state.
+
+        Args:
+            state: Current environment state.
+            params: Environment parameters.
+            key: Optional PRNG key for stochastic observations.
+
+        Returns:
+            Observation array.
+
+        Raises:
+            NotImplementedError: Always; subclasses define the observation model.
+        """
         raise NotImplementedError
 
     def is_terminal(self, state: EnvState, params: EnvParams) -> jnp.ndarray:
+        """Whether the episode has ended.
+
+        An episode terminates when the state flags ``terminal`` or the elapsed
+        time reaches ``params.max_episode_steps``.
+
+        Args:
+            state: Current environment state.
+            params: Environment parameters.
+
+        Returns:
+            Boolean array indicating termination.
+        """
         return jnp.logical_or(state.terminal, state.time >= params.max_episode_steps)
 
     def step_env(self, key: chex.PRNGKey, state: EnvState, action: jnp.array, params: EnvParams):
+        """Advance the environment by one step under the given action.
+
+        Args:
+            key: PRNG key for stochastic transitions.
+            state: Current environment state.
+            action: Control (actuation) input.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, next_state, reward, done, info)``.
+
+        Raises:
+            NotImplementedError: Always; subclasses define the dynamics.
+        """
         raise NotImplementedError
 
 
@@ -306,16 +364,47 @@ class JAXFlowEnvBase(environment.Environment[EnvState, EnvParams]):
     """
 
     def __init__(self, env_config: Optional[dict] = None):
+        """Initialize the environment with an optional configuration dictionary.
+
+        Args:
+            env_config: Environment configuration options (e.g.
+                ``max_episode_steps``); defaults to an empty dict.
+        """
         self.env_config = env_config or {}
 
     def default_params(self) -> EnvParams:
+        """Return the environment's default parameters.
+
+        Sets ``self.max_episode_steps`` from ``env_config`` (default 1000) as a
+        side effect.
+
+        Returns:
+            Default environment parameters.
+
+        Raises:
+            NotImplementedError: Always; subclasses must provide the parameters.
+        """
         self.max_episode_steps = self.env_config.get("max_episode_steps", 1000)
         raise NotImplementedError
 
     def name(self) -> str:
+        """Return the environment's name.
+
+        Raises:
+            NotImplementedError: Always; subclasses must provide a name.
+        """
         raise NotImplementedError
 
     def action_space(self, params: Optional[EnvParams] = None):
+        """Return the (Box) action space bounded by the parameters' action limits.
+
+        Args:
+            params: Environment parameters; defaults to ``self.default_params``.
+
+        Returns:
+            Gymnax Box space of shape ``(params.action_dim,)`` with bounds
+            ``[params.min_action, params.max_action]``.
+        """
         params = params or self.default_params
         return spaces.Box(
             low=params.min_action,
@@ -324,6 +413,15 @@ class JAXFlowEnvBase(environment.Environment[EnvState, EnvParams]):
         )
 
     def observation_space(self, params: EnvParams):
+        """Return the (Box) observation space bounded by the parameters' observation limits.
+
+        Args:
+            params: Environment parameters.
+
+        Returns:
+            Gymnax Box space of shape ``(params.obs_dim,)`` with bounds
+            ``[params.min_obs, params.max_obs]``.
+        """
         return spaces.Box(
             low=params.min_obs,
             high=params.max_obs,
@@ -334,12 +432,46 @@ class JAXFlowEnvBase(environment.Environment[EnvState, EnvParams]):
         return jnp.clip(action, params.min_action, params.max_action)
 
     def is_terminal(self, state: EnvState, params: EnvParams) -> jnp.ndarray:
+        """Whether the episode has ended (state flags ``terminal`` or time limit reached).
+
+        Args:
+            state: Current environment state.
+            params: Environment parameters.
+
+        Returns:
+            Boolean array indicating termination.
+        """
         return jnp.logical_or(state.terminal, state.time >= params.max_episode_steps)
 
     def reset_env(self, key: chex.PRNGKey, params: EnvParams) -> Tuple[chex.Array, EnvState]:
+        """Reset the environment to its initial condition.
+
+        Args:
+            key: PRNG key for stochastic resets.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, state)`` of the initial observation and state.
+
+        Raises:
+            NotImplementedError: Always; subclasses define the actual reset.
+        """
         raise NotImplementedError
 
     def get_obs(self, state: EnvState, params: EnvParams, key=None) -> chex.Array:
+        """Compute the observation from the current environment state.
+
+        Args:
+            state: Current environment state.
+            params: Environment parameters.
+            key: Optional PRNG key for stochastic observations.
+
+        Returns:
+            Observation array.
+
+        Raises:
+            NotImplementedError: Always; subclasses define the observation model.
+        """
         raise NotImplementedError
 
     def step_env(
@@ -349,6 +481,20 @@ class JAXFlowEnvBase(environment.Environment[EnvState, EnvParams]):
         action: chex.Array,
         params: EnvParams,
     ):
+        """Advance the environment by one step under the given action.
+
+        Args:
+            key: PRNG key for stochastic transitions.
+            state: Current environment state.
+            action: Control (actuation) input.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, next_state, reward, done, info)``.
+
+        Raises:
+            NotImplementedError: Always; subclasses define the dynamics.
+        """
         raise NotImplementedError
 
 
@@ -364,6 +510,11 @@ class GymnaxWrapper(object):
     """Base class for Gymnax wrappers."""
 
     def __init__(self, env):
+        """Wrap the given environment.
+
+        Args:
+            env: The Gymnax environment (or wrapper) being wrapped.
+        """
         self._env = env
 
     # provide proxy access to regular attributes of wrapped object
@@ -375,9 +526,22 @@ class FlattenObservationWrapper(GymnaxWrapper):
     """Flatten the observations of the environment."""
 
     def __init__(self, env: environment.Environment):
+        """Wrap the given environment (see :class:`GymnaxWrapper`)."""
         super().__init__(env)
 
     def observation_space(self, params) -> spaces.Box:
+        """Return the wrapped environment's observation space, flattened to 1D.
+
+        Args:
+            params: Environment parameters.
+
+        Returns:
+            Gymnax Box space whose shape is the product of the underlying
+            space's shape, with the same bounds and dtype.
+
+        Raises:
+            AssertionError: If the wrapped space is not a Box.
+        """
         assert isinstance(self._env.observation_space(params), spaces.Box), "Only Box spaces are supported for now."
         return spaces.Box(
             low=self._env.observation_space(params).low,
@@ -390,6 +554,15 @@ class FlattenObservationWrapper(GymnaxWrapper):
     def reset(
         self, key: chex.PRNGKey, params: Optional[environment.EnvParams] = None
     ) -> Tuple[chex.Array, environment.EnvState]:
+        """Reset the wrapped environment and flatten the initial observation.
+
+        Args:
+            key: PRNG key for the reset.
+            params: Environment parameters (None uses the environment default).
+
+        Returns:
+            Tuple ``(obs, state)`` with the flattened observation.
+        """
         obs, state = self._env.reset(key, params)
         obs = jnp.reshape(obs, (-1,))
         return obs, state
@@ -402,6 +575,18 @@ class FlattenObservationWrapper(GymnaxWrapper):
         action: Union[int, float],
         params: Optional[environment.EnvParams] = None,
     ) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]:
+        """Step the wrapped environment and flatten the returned observation.
+
+        Args:
+            key: PRNG key for the transition.
+            state: Current environment state.
+            action: Action to apply.
+            params: Environment parameters (None uses the environment default).
+
+        Returns:
+            Tuple ``(obs, state, reward, done, info)`` with the flattened
+            observation; all other values are passed through unchanged.
+        """
         obs, state, reward, done, info = self._env.step(key, state, action, params)
         obs = jnp.reshape(obs, (-1,))
         return obs, state, reward, done, info
@@ -409,6 +594,17 @@ class FlattenObservationWrapper(GymnaxWrapper):
 
 @struct.dataclass
 class LogEnvState:
+    """State bookkeeping for :class:`LogWrapper`.
+
+    Attributes:
+        env_state: The wrapped environment's own state.
+        episode_returns: Return accumulated so far in the current episode.
+        episode_lengths: Number of steps taken so far in the current episode.
+        returned_episode_returns: Return of the most recently completed episode.
+        returned_episode_lengths: Length of the most recently completed episode.
+        timestep: Total number of steps taken across all episodes.
+    """
+
     env_state: environment.EnvState
     episode_returns: float
     episode_lengths: int
@@ -421,12 +617,22 @@ class LogWrapper(GymnaxWrapper):
     """Log the episode returns and lengths."""
 
     def __init__(self, env: environment.Environment):
+        """Wrap the given environment (see :class:`GymnaxWrapper`)."""
         super().__init__(env)
 
     @partial(jax.jit, static_argnums=(0,))
     def reset(
         self, key: chex.PRNGKey, params: Optional[environment.EnvParams] = None
     ) -> Tuple[chex.Array, environment.EnvState]:
+        """Reset the wrapped environment and zero the episode bookkeeping.
+
+        Args:
+            key: PRNG key for the reset.
+            params: Environment parameters (None uses the environment default).
+
+        Returns:
+            Tuple ``(obs, LogEnvState)`` with all counters initialized to zero.
+        """
         obs, env_state = self._env.reset(key, params)
         state = LogEnvState(env_state, 0, 0, 0, 0, 0)
         return obs, state
@@ -439,6 +645,23 @@ class LogWrapper(GymnaxWrapper):
         action: Union[int, float],
         params: Optional[environment.EnvParams] = None,
     ) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]:
+        """Step the wrapped environment, updating and exporting episode statistics.
+
+        Accumulates the running episode return/length and, on episode end,
+        freezes them into ``returned_episode_returns``/``returned_episode_lengths``
+        before resetting the running counters. These values (plus the global
+        timestep and an ``returned_episode`` done flag) are added to ``info``.
+
+        Args:
+            key: PRNG key for the transition.
+            state: Current :class:`LogEnvState`.
+            action: Action to apply to the wrapped environment.
+            params: Environment parameters (None uses the environment default).
+
+        Returns:
+            Tuple ``(obs, new LogEnvState, reward, done, info)`` with the
+            logging fields added to ``info``.
+        """
         obs, env_state, reward, done, info = self._env.step(key, state.env_state, action, params)
         new_episode_return = state.episode_returns + reward
         new_episode_length = state.episode_lengths + 1
@@ -458,18 +681,59 @@ class LogWrapper(GymnaxWrapper):
 
 
 class NavixGymnaxWrapper:
+    """Adapter exposing a Navix environment through the Gymnax-style API.
+
+    Wraps a Navix environment created from ``env_name`` and translates its
+    reset/step/space API into the ``(obs, state, reward, done, info)`` tuple
+    convention used by the other wrappers here.
+    """
+
     def __init__(self, env_name):
+        """Create the underlying Navix environment.
+
+        Args:
+            env_name: Name of the Navix environment (passed to ``navix.make``).
+        """
         self._env = nx.make(env_name)
 
     def reset(self, key, params=None):
+        """Reset the Navix environment.
+
+        Args:
+            key: PRNG key for the reset.
+            params: Unused; accepted for Gymnax API compatibility.
+
+        Returns:
+            Tuple ``(observation, timestep)`` from the Navix reset.
+        """
         timestep = self._env.reset(key)
         return timestep.observation, timestep
 
     def step(self, key, state, action, params=None):
+        """Step the Navix environment.
+
+        Args:
+            key: Unused; accepted for Gymnax API compatibility.
+            state: Current Navix timestep (used as the environment state).
+            action: Action to apply.
+            params: Unused; accepted for Gymnax API compatibility.
+
+        Returns:
+            Tuple ``(observation, timestep, reward, done, info)`` where ``info``
+            is always an empty dict.
+        """
         timestep = self._env.step(state, action)
         return timestep.observation, timestep, timestep.reward, timestep.is_done(), {}
 
     def observation_space(self, params):
+        """Return the flattened Navix observation space as a Gymnax Box.
+
+        Args:
+            params: Unused; accepted for Gymnax API compatibility.
+
+        Returns:
+            Gymnax Box with the Navix space's bounds, flattened shape, and dtype.
+        """
         return spaces.Box(
             low=self._env.observation_space.minimum,
             high=self._env.observation_space.maximum,
@@ -478,50 +742,134 @@ class NavixGymnaxWrapper:
         )
 
     def action_space(self, params):
+        """Return the Navix action space as a Gymnax Discrete space.
+
+        Args:
+            params: Unused; accepted for Gymnax API compatibility.
+
+        Returns:
+            Gymnax Discrete space with the number of Navix action categories.
+        """
         return spaces.Discrete(
             num_categories=self._env.action_space.maximum.item() + 1,
         )
 
 
 class ClipAction(GymnaxWrapper):
+    """Wrapper that clips actions to a fixed range before stepping the environment."""
+
     def __init__(self, env, low=-1.0, high=1.0):
+        """Wrap the environment and store the clipping bounds.
+
+        Args:
+            env: The environment being wrapped.
+            low: Lower bound for clipping actions.
+            high: Upper bound for clipping actions.
+        """
         super().__init__(env)
         self.low = low
         self.high = high
 
     def step(self, key, state, action, params=None):
-        """TODO: In theory the below line should be the way to do this."""
+        """Clip the action to ``[low, high]`` and step the wrapped environment.
+
+        Args:
+            key: PRNG key for the transition.
+            state: Current environment state.
+            action: Action to clip and apply.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, state, reward, done, info)`` from the wrapped environment.
+
+        Note:
+            TODO: In theory the clip bounds should come from the action space.
+        """
         # action = jnp.clip(action, self.env.action_space.low, self.env.action_space.high)
         action = jnp.clip(action, self.low, self.high)
         return self._env.step(key, state, action, params)
 
 
 class TransformObservation(GymnaxWrapper):
+    """Wrapper that applies a function to the observation after reset and step."""
+
     def __init__(self, env, transform_obs):
+        """Wrap the environment and store the observation transform.
+
+        Args:
+            env: The environment being wrapped.
+            transform_obs: Callable applied to every observation.
+        """
         super().__init__(env)
         self.transform_obs = transform_obs
 
     def reset(self, key, params=None):
+        """Reset the wrapped environment and transform the initial observation.
+
+        Args:
+            key: PRNG key for the reset.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(transformed obs, state)``.
+        """
         obs, state = self._env.reset(key, params)
         return self.transform_obs(obs), state
 
     def step(self, key, state, action, params=None):
+        """Step the wrapped environment and transform the returned observation.
+
+        Args:
+            key: PRNG key for the transition.
+            state: Current environment state.
+            action: Action to apply.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(transformed obs, state, reward, done, info)``.
+        """
         obs, state, reward, done, info = self._env.step(key, state, action, params)
         return self.transform_obs(obs), state, reward, done, info
 
 
 class TransformReward(GymnaxWrapper):
+    """Wrapper that applies a function to the reward after each step."""
+
     def __init__(self, env, transform_reward):
+        """Wrap the environment and store the reward transform.
+
+        Args:
+            env: The environment being wrapped.
+            transform_reward: Callable applied to every reward.
+        """
         super().__init__(env)
         self.transform_reward = transform_reward
 
     def step(self, key, state, action, params=None):
+        """Step the wrapped environment and transform the returned reward.
+
+        Args:
+            key: PRNG key for the transition.
+            state: Current environment state.
+            action: Action to apply.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, state, transformed reward, done, info)``.
+        """
         obs, state, reward, done, info = self._env.step(key, state, action, params)
         return obs, state, self.transform_reward(reward), done, info
 
 
 class VecEnv(GymnaxWrapper):
+    """Wrapper that vectorizes the wrapped environment's reset and step over batched keys/states/actions."""
+
     def __init__(self, env):
+        """Wrap the environment and install vmapped reset/step methods.
+
+        Args:
+            env: The environment being wrapped.
+        """
         super().__init__(env)
         self.reset = jax.vmap(self._env.reset, in_axes=(0, None))
         self.step = jax.vmap(self._env.step, in_axes=(0, 0, 0, None))
@@ -529,6 +877,15 @@ class VecEnv(GymnaxWrapper):
 
 @struct.dataclass
 class NormalizeVecObsEnvState:
+    """Running-normalization bookkeeping for :class:`NormalizeVecObservation`.
+
+    Attributes:
+        mean: Running per-dimension mean of the observations.
+        var: Running per-dimension variance of the observations.
+        count: Running count of observations seen so far.
+        env_state: The wrapped environment's own state.
+    """
+
     mean: jnp.ndarray
     var: jnp.ndarray
     count: float
@@ -536,10 +893,27 @@ class NormalizeVecObsEnvState:
 
 
 class NormalizeVecObservation(GymnaxWrapper):
+    """Wrapper that normalizes vectorized observations with a running mean/variance.
+
+    Statistics are updated from the batch of observations at every reset/step
+    (Welford-style parallel-variant merge) and observations are returned as
+    ``(obs - mean) / sqrt(var + 1e-8)``.
+    """
+
     def __init__(self, env):
+        """Wrap the given environment (see :class:`GymnaxWrapper`)."""
         super().__init__(env)
 
     def reset(self, key, params=None):
+        """Reset the wrapped environment and initialize/update the observation statistics.
+
+        Args:
+            key: PRNG key for the reset.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(normalized obs, NormalizeVecObsEnvState)``.
+        """
         obs, state = self._env.reset(key, params)
         state = NormalizeVecObsEnvState(
             mean=jnp.zeros_like(obs),
@@ -571,6 +945,22 @@ class NormalizeVecObservation(GymnaxWrapper):
         return (obs - state.mean) / jnp.sqrt(state.var + 1e-8), state
 
     def step(self, key, state, action, params=None):
+        """Step the wrapped environment and normalize the observation batch.
+
+        The running mean/variance are first merged with the batch statistics of
+        the new observations; the returned observation is the batch normalized
+        with the updated statistics.
+
+        Args:
+            key: PRNG key for the transition.
+            state: Current :class:`NormalizeVecObsEnvState`.
+            action: Batched actions to apply.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(normalized obs, updated NormalizeVecObsEnvState, reward,
+            done, info)``.
+        """
         obs, env_state, reward, done, info = self._env.step(key, state.env_state, action, params)
 
         batch_mean = jnp.mean(obs, axis=0)
@@ -604,6 +994,16 @@ class NormalizeVecObservation(GymnaxWrapper):
 
 @struct.dataclass
 class NormalizeVecRewEnvState:
+    """Running-normalization bookkeeping for :class:`NormalizeVecReward`.
+
+    Attributes:
+        mean: Running mean of the discounted episode returns.
+        var: Running variance of the discounted episode returns.
+        count: Running count of return samples seen so far.
+        return_val: Current discounted episode return per environment.
+        env_state: The wrapped environment's own state.
+    """
+
     mean: jnp.ndarray
     var: jnp.ndarray
     count: float
@@ -612,11 +1012,34 @@ class NormalizeVecRewEnvState:
 
 
 class NormalizeVecReward(GymnaxWrapper):
+    """Wrapper that normalizes vectorized rewards by the running variance of the discounted returns.
+
+    Rewards are accumulated per environment with discount factor ``gamma`` and
+    each reward is divided by ``sqrt(var + 1e-8)`` of the running return
+    statistics.
+    """
+
     def __init__(self, env, gamma):
+        """Wrap the environment and store the discount factor.
+
+        Args:
+            env: The environment being wrapped.
+            gamma: Discount factor used to accumulate episode returns.
+        """
         super().__init__(env)
         self.gamma = gamma
 
     def reset(self, key, params=None):
+        """Reset the wrapped environment and zero the return statistics.
+
+        Args:
+            key: PRNG key for the reset.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, NormalizeVecRewEnvState)`` with mean 0, variance 1,
+            and zeroed per-environment returns.
+        """
         obs, state = self._env.reset(key, params)
         batch_count = obs.shape[0]
         state = NormalizeVecRewEnvState(
@@ -629,6 +1052,23 @@ class NormalizeVecReward(GymnaxWrapper):
         return obs, state
 
     def step(self, key, state, action, params=None):
+        """Step the wrapped environment and scale the reward by the running return std.
+
+        The discounted episode return is updated per environment
+        (``return_val * gamma * (1 - done) + reward``) and merged into the
+        running mean/variance statistics; the reward is then divided by
+        ``sqrt(var + 1e-8)`` before being returned.
+
+        Args:
+            key: PRNG key for the transition.
+            state: Current :class:`NormalizeVecRewEnvState`.
+            action: Batched actions to apply.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, updated NormalizeVecRewEnvState, scaled reward, done,
+            info)``.
+        """
         obs, env_state, reward, done, info = self._env.step(key, state.env_state, action, params)
         return_val = state.return_val * self.gamma * (1 - done) + reward
 

--- a/hydrogym/jax/envs/channel.py
+++ b/hydrogym/jax/envs/channel.py
@@ -472,6 +472,7 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         Nw = u * dw_dx + v * dw_dy + w * dw_dz
 
         def forcing_hat(f):
+            """Broadcast a scalar forcing to the full grid (or pass a field through) and FFT it in x/y."""
             if jnp.ndim(f) == 0:
                 f_phys = jnp.ones((self.Nx, self.Ny, self.Nz), dtype=self.dtype) * f
             else:
@@ -655,6 +656,7 @@ def run_channel_pseudospectral(
     state0 = equation.to_spectral(VelocityState(U0, V0, W0))
 
     def step_fn(state, n):
+        """One RK4 substep: constant body forcing ``fx = 2.0``, time = substep index."""
         t = n
         fx = 2.0
         new_state = integrator.rk4_step(
@@ -943,6 +945,7 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
         state0 = self.equation.to_spectral(VelocityState(state.U, state.V, state.W))
 
         def step_fn(state_hat, n):
+            """One checkpointed RK4 substep at absolute time ``state.time + n`` (constant forcing ``fx = 2.0``)."""
             t = state.time + n
             fx = 2.0
 

--- a/hydrogym/jax/envs/channel.py
+++ b/hydrogym/jax/envs/channel.py
@@ -53,6 +53,17 @@ class ChannelEnvParams(BaseEnvParams):
 
 @struct.dataclass
 class ChannelEnvState(environment.EnvState):
+    """Channel-flow environment state (physical-space velocity fields).
+
+    Attributes:
+        time: Simulation time (in DNS steps) elapsed in the episode.
+        U: Streamwise velocity field, shape (Nx, Ny, Nz).
+        V: Wall-normal velocity field, shape (Nx, Ny, Nz).
+        W: Spanwise velocity field, shape (Nx, Ny, Nz).
+        dt: Current DNS timestep.
+        terminal: Whether the episode has terminated.
+    """
+
     time: int
     U: jnp.ndarray
     V: jnp.ndarray
@@ -62,12 +73,31 @@ class ChannelEnvState(environment.EnvState):
 
 
 class SpectralState(NamedTuple):
+    """Three-component spectral (FFT'd) velocity state.
+
+    Attributes:
+        u_hat: x-component spectrum, shape (Nx, Ny, Nz), complex.
+        v_hat: y-component spectrum.
+        w_hat: z-component spectrum.
+    """
+
     u_hat: jnp.ndarray  # (Nx,Ny,Nz), complex
     v_hat: jnp.ndarray
     w_hat: jnp.ndarray
 
 
 def make_obs_grid_indices(Nx: int, Ny: int, n: int):
+    """Build the (x, y) index grid used to subsample the observation plane.
+
+    Args:
+        Nx: Number of grid points in x.
+        Ny: Number of grid points in y.
+        n: Number of subsample points along each axis.
+
+    Returns:
+        Tuple ``(Xi, Yi)`` of index arrays of shape (n, n) spanning the full
+        x/y ranges, suitable for advanced indexing of a slice of the state.
+    """
     xs = jnp.linspace(0, Nx - 1, n).astype(jnp.int64)
     ys = jnp.linspace(0, Ny - 1, n).astype(jnp.int64)
     Xi, Yi = jnp.meshgrid(xs, ys, indexing="ij")
@@ -80,6 +110,20 @@ def get_obs_spectral_channel(
     Xi: jnp.ndarray,
     Yi: jnp.ndarray,
 ) -> chex.Array:
+    """Extract the channel-flow observation vector from the current state.
+
+    Samples the streamwise (U) and spanwise (W) velocity at the subsampled
+    grid points on the wall-parallel plane ``z = params.k_det``.
+
+    Args:
+        state: Current channel environment state.
+        params: Channel environment parameters.
+        Xi: Observation x-index grid (from :func:`make_obs_grid_indices`).
+        Yi: Observation y-index grid.
+
+    Returns:
+        1D array of the sampled U and W values stacked and flattened.
+    """
     k = params.k_det
     Usl = state.U[:, :, k]
     Wsl = state.W[:, :, k]
@@ -87,6 +131,21 @@ def get_obs_spectral_channel(
 
 
 def wss_compute(k, U, nu=1.9e-3, z=None):
+    """Compute the domain-mean wall shear stress from a finite-difference gradient.
+
+    Approximates the wall-normal velocity gradient at the wall by a one-sided
+    difference between wall-parallel slices ``k`` and ``0``, using the physical
+    z-coordinates in ``z``.
+
+    Args:
+        k: Index of the near-wall slice used for the finite difference.
+        U: Streamwise velocity field, shape (Nx, Ny, Nz).
+        nu: Kinematic viscosity used to convert the gradient to stress.
+        z: Physical z-coordinates of the grid points (1D array).
+
+    Returns:
+        Mean wall shear stress over the (Nx, Ny) plane.
+    """
     dz = z[k] - z[0]
     du_dz_wall = (U[:, :, k] - U[:, :, 0]) / dz
     tau_w = nu * du_dz_wall
@@ -101,7 +160,34 @@ def wss_compute(k, U, nu=1.9e-3, z=None):
 
 
 class PseudoSpectralNavierStokes3D(SplitEquation):
+    """Pseudo-spectral 3D Navier-Stokes equation for a channel flow.
+
+    Horizontal (x, y) directions are treated spectrally with FFTs and the
+    wall-normal (z) direction with Chebyshev collocation. The state is the
+    triple of spectral velocity components on the (Nx, Ny, Nz) grid. The
+    incompressibility constraint is enforced by a pressure Poisson solve whose
+    per-horizontal-wavenumber Chebyshev matrices are pre-inverted at
+    construction, with the no-penetration wall condition folded in.
+
+    The pressure solver imposes the mean-pressure gauge by pinning one grid
+    point (the zero-wavenumber row), and the wall-normal pressure-gradient
+    boundary conditions (from the wall values of w) are applied in
+    :meth:`project`.
+    """
+
     def __init__(self, Nx, Ny, Nz, Lx, Ly, Lz, nu, dtype=jnp.float32):
+        """Precompute wavenumbers, derivative operators, dealiasing mask, and pressure solver.
+
+        Args:
+            Nx: Number of grid points in x.
+            Ny: Number of grid points in y.
+            Nz: Number of Chebyshev collocation points in z.
+            Lx: Domain length in x.
+            Ly: Domain length in y.
+            Lz: Domain height in z.
+            nu: Kinematic viscosity.
+            dtype: Floating dtype for the precomputed operators.
+        """
         self.Nx = Nx
         self.Ny = Ny
         self.Nz = Nz
@@ -147,12 +233,36 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         self.A_inv = jax.vmap(jnp.linalg.inv)(A)
 
     def fft_xy(self, f):
+        """Forward FFT of a field over the horizontal (x, y) axes.
+
+        Args:
+            f: Physical-space field of shape (Nx, Ny, Nz).
+
+        Returns:
+            Spectral field of the same shape.
+        """
         return jnp.fft.fftn(f, axes=(0, 1))
 
     def ifft_xy(self, f_hat):
+        """Inverse FFT of a field over the horizontal (x, y) axes, taking the real part.
+
+        Args:
+            f_hat: Spectral field of shape (Nx, Ny, Nz).
+
+        Returns:
+            Physical-space (real) field of the same shape.
+        """
         return jnp.fft.ifftn(f_hat, axes=(0, 1)).real
 
     def to_spectral(self, state: "VelocityState") -> "VelocityState":
+        """Transform a physical-space velocity state to spectral space.
+
+        Args:
+            state: Physical-space :class:`VelocityState`.
+
+        Returns:
+            Spectral-space :class:`VelocityState`.
+        """
         return VelocityState(
             self.fft_xy(state.u),
             self.fft_xy(state.v),
@@ -160,6 +270,14 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         )
 
     def to_physical(self, state_hat: "VelocityState") -> "VelocityState":
+        """Transform a spectral velocity state to physical space.
+
+        Args:
+            state_hat: Spectral-space :class:`VelocityState`.
+
+        Returns:
+            Physical-space :class:`VelocityState`.
+        """
         return VelocityState(
             self.ifft_xy(state_hat.u),
             self.ifft_xy(state_hat.v),
@@ -167,15 +285,47 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         )
 
     def dx_hat(self, f_hat):
+        """x-derivative of a spectral field (multiplication by i*kx).
+
+        Args:
+            f_hat: Spectral field.
+
+        Returns:
+            Spectral x-derivative.
+        """
         return self.ikx * f_hat
 
     def dy_hat(self, f_hat):
+        """y-derivative of a spectral field (multiplication by i*ky).
+
+        Args:
+            f_hat: Spectral field.
+
+        Returns:
+            Spectral y-derivative.
+        """
         return self.iky * f_hat
 
     def dz_phys(self, f_phys):
+        """First z-derivative of a physical field via the Chebyshev matrix.
+
+        Args:
+            f_phys: Physical-space field of shape (Nx, Ny, Nz).
+
+        Returns:
+            z-derivative of the same shape.
+        """
         return jnp.einsum("ij,xyj->xyi", self.Dz, f_phys)
 
     def dzz_phys(self, f_phys):
+        """Second z-derivative of a physical field via the Chebyshev matrix.
+
+        Args:
+            f_phys: Physical-space field of shape (Nx, Ny, Nz).
+
+        Returns:
+            Second z-derivative of the same shape.
+        """
         return jnp.einsum("ij,xyj->xyi", self.Dzz, f_phys)
 
     def apply_jets_v(
@@ -190,6 +340,29 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         nx_jets=6,
         ny_jets=4,
     ):
+        """Imprint a grid of wall-normal jet velocity profiles onto the v-field.
+
+        A periodic array of ``nx_jets x ny_jets`` Gaussian jets centered on the
+        bottom wall builds a velocity mask from the per-jet amplitudes in
+        ``Vjets``; the mask is mean-subtracted (zero net blowing) and written
+        into the wall-normal component ``v`` over ``jet_thickness`` layers
+        starting at wall layer ``z0``. The wall layers of ``v`` are first set
+        to zero.
+
+        Args:
+            v: Wall-normal velocity field, shape (Nx, Ny, Nz).
+            Vjets: Jet amplitudes, shape (nx_jets, ny_jets).
+            z0: First wall-normal layer the jets penetrate.
+            jet_thickness: Number of layers the jets span.
+            slit_length_x: Gaussian width of each jet in x.
+            slit_width_y: Gaussian width of each jet in y.
+            x_span_frac: Fraction of the x domain covered by the jet array.
+            nx_jets: Number of jets along x.
+            ny_jets: Number of jets along y.
+
+        Returns:
+            The modified wall-normal velocity field.
+        """
         Nx, Ny, Nz = v.shape
         v = v.at[:, :, 0].set(0.0)
         v = v.at[:, :, -1].set(0.0)
@@ -221,6 +394,26 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         return v
 
     def enforce_noslip(self, u, v, w, action=None, action_time=50.0, t=0.0):
+        """Apply the wall boundary conditions to a physical-space velocity state.
+
+        u and v are forced to zero at both walls. For w, an actuation ramp is
+        applied: if an ``action`` is given, the wall-normal jets
+        (:meth:`apply_jets_v`) are driven with amplitude proportional to the
+        action, scaled by a gain that ramps linearly up over the first 10 time
+        units and down over the last 10 before ``action_time``; without an
+        action, w is simply set to zero at the walls.
+
+        Args:
+            u: Streamwise velocity field, shape (Nx, Ny, Nz).
+            v: Wall-normal velocity field.
+            w: Spanwise velocity field.
+            action: Jet control amplitudes, or None for the unactuated case.
+            action_time: Total actuation window over which the gain ramps up and down.
+            t: Current time, used for the gain ramp.
+
+        Returns:
+            Tuple ``(u, v, w)`` with the boundary conditions applied.
+        """
         u = u.at[:, :, 0].set(0.0).at[:, :, -1].set(0.0)
         v = v.at[:, :, 0].set(0.0).at[:, :, -1].set(0.0)
 
@@ -237,6 +430,25 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         return u, v, w
 
     def nonlinear_terms(self, state_hat, action=None, t=0.0, fx=0.0, fy=0.0, fz=0.0):
+        """Evaluate the explicitly treated (nonlinear advection + forcing) terms.
+
+        The state is transformed to physical space, wall boundary conditions
+        (and jets, if actuated) are applied, and the advective terms
+        ``u · ∇u`` are computed with spectral x/y derivatives and Chebyshev
+        z-derivatives. The result is returned in spectral space with the 2/3
+        dealiasing mask applied and the body forcing added.
+
+        Args:
+            state_hat: Spectral velocity state.
+            action: Jet control amplitudes, or None.
+            t: Current time (used for the actuation gain ramp).
+            fx: x-direction body forcing (scalar or physical-space field).
+            fy: y-direction body forcing.
+            fz: z-direction body forcing.
+
+        Returns:
+            Spectral :class:`VelocityState` of the nonlinear terms.
+        """
         state = self.to_physical(state_hat)
         u, v, w = self.enforce_noslip(state.u, state.v, state.w, action=action, t=t)
 
@@ -277,6 +489,20 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         )
 
     def linear_terms(self, state_hat, action=None, t=0.0):
+        """Evaluate the implicitly treated (viscous diffusion) term.
+
+        Computes ``nu * (∂²u/∂z² - k²u)`` for each component, combining the
+        Chebyshev second z-derivative in physical space with the horizontal
+        Laplacian applied spectrally.
+
+        Args:
+            state_hat: Spectral velocity state.
+            action: Unused; present for interface compatibility.
+            t: Unused; present for interface compatibility.
+
+        Returns:
+            Spectral :class:`VelocityState` of the linear terms.
+        """
         state = self.to_physical(state_hat)
         u, v, w = self.enforce_noslip(state.u, state.v, state.w, action=action, t=t)
 
@@ -292,6 +518,19 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         )
 
     def rhs(self, state_hat, action=None, t=0.0, fx=0.0, fy=0.0, fz=0.0):
+        """Evaluate the full right-hand side as nonlinear + linear terms.
+
+        Args:
+            state_hat: Spectral velocity state.
+            action: Jet control amplitudes, or None.
+            t: Current time.
+            fx: x-direction body forcing.
+            fy: y-direction body forcing.
+            fz: z-direction body forcing.
+
+        Returns:
+            Spectral :class:`VelocityState` of the full right-hand side.
+        """
         N = self.nonlinear_terms(state_hat, action=action, t=t, fx=fx, fy=fy, fz=fz)
         L = self.linear_terms(state_hat, action=action, t=t)
         return VelocityState(
@@ -301,6 +540,25 @@ class PseudoSpectralNavierStokes3D(SplitEquation):
         )
 
     def project(self, state_hat, dt, action=None, t=0.0):
+        """Project the state onto the divergence-free (incompressibility) constraint.
+
+        Solves the pressure Poisson problem for the divergence error over one
+        timestep using the precomputed per-wavenumber inverse Chebyshev
+        matrices, with the wall-normal pressure-gradient conditions derived
+        from the wall values of w, and the mean-pressure gauge pinned at the
+        zero-wavenumber mode. The velocity is corrected by the pressure
+        gradient, the boundary conditions (and jets, if actuated) are
+        re-applied, and the result is returned in spectral space.
+
+        Args:
+            state_hat: Spectral velocity state to project.
+            dt: Timestep used in the pressure correction.
+            action: Jet control amplitudes, or None.
+            t: Current time (used for the actuation gain ramp).
+
+        Returns:
+            Projected spectral :class:`VelocityState`.
+        """
         u_hat = state_hat.u
         v_hat = state_hat.v
         w_hat = state_hat.w
@@ -367,6 +625,33 @@ def run_channel_pseudospectral(
     return_trajectory: bool = False,
     checkpoint_steps: bool = True,
 ):
+    """Run a channel-flow DNS rollout of ``nsteps`` RK4 steps.
+
+    The initial physical fields are transformed to spectral space, advanced
+    with ``integrator.rk4_step`` for ``nsteps`` substeps (constant body forcing
+    ``fx = 2.0``, constant-mass-flux correction toward a bulk velocity of 8.0),
+    and returned either as a trajectory of physical-space snapshots or as the
+    final state only.
+
+    Args:
+        U0: Initial streamwise velocity field, shape (Nx, Ny, Nz).
+        V0: Initial wall-normal velocity field.
+        W0: Initial spanwise velocity field.
+        action: Jet control amplitudes applied at every substep, or None.
+        dt: DNS timestep.
+        equation: The pseudo-spectral equation (provides transforms).
+        integrator: The RK4 integrator to step with.
+        nsteps: Number of DNS substeps to run.
+        return_trajectory: If True, return the full trajectory of physical
+            velocity fields instead of just the final state.
+        checkpoint_steps: If True, wrap the step function in ``jax.checkpoint``
+            to trade compute for reduced memory during the scan.
+
+    Returns:
+        If ``return_trajectory``: arrays ``(U, V, W)`` of trajectories with a
+        leading time axis of length ``nsteps``; otherwise the final state's
+        physical ``(u, v, w)`` fields.
+    """
     state0 = equation.to_spectral(VelocityState(U0, V0, W0))
 
     def step_fn(state, n):
@@ -412,6 +697,24 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
     """
 
     def __init__(self, env_config: Dict):
+        """Build the equation, integrator, and initial fields for the channel.
+
+        Physical/spectral grid parameters are taken from ``env_config`` (with
+        defaults matching the previously hardcoded values). Initial velocity
+        fields are loaded either from a local directory or from Hugging Face
+        (see the source comments for the accepted overrides).
+
+        Args:
+            env_config: Configuration dictionary; recognized keys include
+                ``Lx``/``Ly``/``Lz`` (domain extents), ``nu`` (viscosity),
+                ``Nx``/``Ny``/``Nz`` (grid resolution, note that non-default
+                values change the JIT-compiled operator shapes and require
+                matching initial-field shapes), ``dtype`` ("float32" or
+                "float64"), ``initial_field_dir`` (local directory containing
+                U/V/W.npy), and the HFDataManager forwarding options
+                ``hf_repo_id``/``cache_dir``/``use_clean_cache``/
+                ``local_fallback_dir``/``hf_token``/``hf_revision``.
+        """
         super().__init__(env_config)
         # Physical/spectral grid parameters. Defaults preserve the previously
         # hardcoded values exactly; env_config overrides exist for running
@@ -474,13 +777,25 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
 
     @property
     def default_params(self) -> ChannelEnvParams:
+        """Default :class:`ChannelEnvParams` for this environment."""
         return ChannelEnvParams()
 
     @property
     def name(self) -> str:
+        """Name of this environment."""
         return "ChannelFlowSpectralEnv"
 
     def reset_env(self, key: chex.PRNGKey, params: ChannelEnvParams) -> Tuple[chex.Array, ChannelEnvState]:
+        """Reset the channel to the stored initial fields.
+
+        Args:
+            key: PRNG key (forwarded to the observation function; the reset
+                itself is deterministic).
+            params: Channel environment parameters.
+
+        Returns:
+            Tuple ``(obs, ChannelEnvState)`` at time 0 with ``terminal=False``.
+        """
         state = ChannelEnvState(
             time=0,
             U=self.U0,
@@ -493,9 +808,28 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
         return obs, state
 
     def get_obs(self, state: ChannelEnvState, params: ChannelEnvParams, key=None) -> chex.Array:
+        """Sample the subsampled U/W observation plane at ``k_det``.
+
+        Args:
+            state: Current channel environment state.
+            params: Channel environment parameters.
+            key: Unused; accepted for API compatibility.
+
+        Returns:
+            1D observation array (see :func:`get_obs_spectral_channel`).
+        """
         return get_obs_spectral_channel(state, params, self.Xi_obs, self.Yi_obs)
 
     def is_terminal(self, state: ChannelEnvState, params: ChannelEnvParams) -> jnp.ndarray:
+        """Whether the episode has ended (``terminal`` flag or step limit reached).
+
+        Args:
+            state: Current channel environment state.
+            params: Channel environment parameters.
+
+        Returns:
+            Boolean array indicating termination.
+        """
         return jnp.logical_or(state.terminal, state.time >= params.max_steps_in_episode)
 
     def step_env(
@@ -505,6 +839,25 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
         action: jnp.ndarray,
         params: ChannelEnvParams,
     ) -> Tuple[chex.Array, ChannelEnvState, jnp.ndarray, jnp.ndarray, Dict]:
+        """Advance the channel flow by ``params.nsteps`` DNS substeps under the given jet action.
+
+        The action is clipped to the parameter bounds and the wall shear stress
+        after the rollout is differentiated with respect to the action (via
+        ``jax.value_and_grad``) to obtain the reward ``-wss`` together with its
+        gradient.
+
+        Args:
+            key: PRNG key (forwarded to the observation function; the dynamics
+                are deterministic).
+            state: Current channel environment state.
+            action: Jet control input (clipped to ``[min_action, max_action]``).
+            params: Channel environment parameters.
+
+        Returns:
+            Tuple ``(obs, next_state, reward, done, info)`` where ``info``
+            contains ``"discount"``. (The reward gradient w.r.t. the action is
+            computed as ``grad_wss`` but is not currently returned.)
+        """
         action = jnp.clip(action, params.min_action, params.max_action)
 
         (wss, (U1, V1, W1)), grad_wss = jax.value_and_grad(
@@ -532,6 +885,16 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
         return obs, next_state, reward, done, {"discount": self.discount(next_state, params)}
 
     def action_space(self, params: Optional[ChannelEnvParams] = None) -> spaces.Box:
+        """Return the jet-control action space.
+
+        Args:
+            params: Channel environment parameters; defaults to
+                ``self.default_params``.
+
+        Returns:
+            Gymnax Box of shape ``(params.action_dim,)`` with bounds
+            ``[params.min_action, params.max_action]``.
+        """
         params = params or self.default_params
         return spaces.Box(
             low=params.min_action,
@@ -540,6 +903,17 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
         )
 
     def observation_space(self, params: Optional[ChannelEnvParams] = None) -> spaces.Box:
+        """Return the (unbounded) observation space.
+
+        Args:
+            params: Channel environment parameters; defaults to
+                ``self.default_params``.
+
+        Returns:
+            Gymnax Box of shape
+            ``(params.obs_subsample**2 * params.obs_include_components,)`` with
+            infinite bounds.
+        """
         params = params or self.default_params
         obs_dim = params.obs_subsample**2 * params.obs_include_components
         return spaces.Box(low=-jnp.inf, high=jnp.inf, shape=(obs_dim,))
@@ -550,6 +924,22 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase):
         action: jnp.ndarray,
         params: ChannelEnvParams,
     ):
+        """Roll the flow forward ``nsteps`` DNS substeps and compute the mean wall shear stress.
+
+        Differentiable through the action: the rollout runs under
+        ``jax.checkpoint`` so ``jax.value_and_grad`` in :meth:`step_env` can
+        propagate gradients from the wall shear stress back to the jet action.
+
+        Args:
+            state: Current channel environment state (physical-space fields).
+            action: Jet control amplitudes applied at every substep.
+            params: Channel environment parameters (only ``nsteps`` is read).
+
+        Returns:
+            Tuple ``(wss, aux)`` where ``wss`` is the mean wall shear stress of
+            the final state and ``aux`` is the final physical-space velocity
+            tuple ``(U1, V1, W1)``.
+        """
         state0 = self.equation.to_spectral(VelocityState(state.U, state.V, state.W))
 
         def step_fn(state_hat, n):

--- a/hydrogym/jax/envs/kolmogorov.py
+++ b/hydrogym/jax/envs/kolmogorov.py
@@ -22,6 +22,15 @@ from hydrogym.jax.utils.utils import compute_real_velocity_point, compute_tke, c
 
 
 class FlowConfig(PDEBase):
+    """Flow configuration for the 2D Kolmogorov flow on a periodic square domain.
+
+    Holds the forcing wavenumber ``k``, Reynolds number ``Re``, grid size,
+    domain extents, and observation size, and provides the real/Fourier meshes,
+    the divergence-free initial condition, the sinusoidal forcing, and the
+    observation extraction used by the environment. The state stored in
+    ``self.vorticity`` (and ``self.state``) is the FFT of the vorticity field.
+    """
+
     DEFAULT_REYNOLDS = 200
     DEFAULT_WAVENUMBER = 4
     DEFAULT_GRID_SIZE = (64, 64)
@@ -30,6 +39,16 @@ class FlowConfig(PDEBase):
     DEFAULT_OBS_SIZE = 8  # This correlates to a total observation size of 8x8 = 64.
 
     def __init__(self, **config):
+        """Read the flow-configuration options and set up the control field.
+
+        Args:
+            **config: Optional overrides: ``k`` (forcing wavenumber, default 4),
+                ``Re`` (Reynolds number, default 200), ``grid_size`` ((ny, nx)
+                tuple, default (64, 64)), ``domain_x``/``domain_y`` (extent
+                tuples, default (0, 2π)), ``obs_size`` (observation grid side,
+                default 8). Remaining keys are forwarded to
+                :class:`~hydrogym.core.PDEBase`.
+        """
         # Keys are popped (not just read) so PDEBase's unknown-key warning
         # (audit Task 2.1) only fires on genuinely unknown options.
         self.k = config.pop("k", self.DEFAULT_WAVENUMBER)
@@ -67,9 +86,20 @@ class FlowConfig(PDEBase):
         return point_velocity
 
     def state(self) -> jnp.array:
+        """Return the current flow state (the FFT'd vorticity field)."""
         return self.state
 
     def get_observations(self) -> jnp.array:
+        """Compute velocity-magnitude observations over the whole stored trajectory.
+
+        For each saved vorticity snapshot in ``self.vorticity``, the velocity is
+        reconstructed in Fourier space and evaluated on a regularly subsampled
+        grid of ``obs_size x obs_size`` points.
+
+        Returns:
+            Array of observations with a leading axis over the trajectory
+            (shape (n_saved, obs_size * obs_size)).
+        """
         n, m = self.grid_size
         divisor = n // self.obs_size
 
@@ -131,6 +161,7 @@ class FlowConfig(PDEBase):
         return self.vorticity
 
     def set_BCs(self):
+        """Apply boundary conditions (no-op; the domain is fully periodic)."""
         # Set the boundary conditions
         pass
 
@@ -148,11 +179,12 @@ class FlowConfig(PDEBase):
         return (jnp.sin(k * y), jnp.zeros_like(y))
 
     def evaluate_objective(self):
-        """Return a copy of the flow state"""
+        """Evaluate the control objective (not implemented; returns None)."""
         pass
 
     @property
     def nu(self):
+        """Kinematic viscosity ``1 / Re``."""
         return 1 / self.Re
 
     @property
@@ -182,6 +214,7 @@ class FlowConfig(PDEBase):
         pass
 
     def load_checkpoint(self, filename: str):
+        """Load a saved flow state from disk (not implemented)."""
         pass
 
 
@@ -202,6 +235,12 @@ class PseudoSpectralNavierStokes2D(IMEXEquation):
     """
 
     def __init__(self, flow: FlowConfig):
+        """Store the flow configuration and cache its Fourier and real-space meshes.
+
+        Args:
+            flow: The :class:`FlowConfig` providing the grid, viscosity, and
+                forcing for the equation.
+        """
         self.flow = flow
         self.grid = flow.load_fft_mesh()
         self.real_grid = flow.load_mesh("name")
@@ -303,6 +342,16 @@ class PseudoSpectralNavierStokes2D(IMEXEquation):
 
 @struct.dataclass
 class KolmogorovFlowState(environment.EnvState):
+    """Kolmogorov-flow environment state.
+
+    Attributes:
+        trajectory: Saved spectral vorticity snapshots of the last rollout
+            (leading axis over time).
+        omega_hat: Final spectral vorticity of the last rollout.
+        time: Number of RL steps taken in the current episode.
+        terminal: Whether the episode has terminated.
+    """
+
     trajectory: jnp.ndarray
     omega_hat: jnp.ndarray
     time: jnp.ndarray
@@ -311,6 +360,26 @@ class KolmogorovFlowState(environment.EnvState):
 
 @struct.dataclass
 class KolmogorovFlowParams(EnvParams):
+    """Gymnax parameters for the Kolmogorov-flow environment.
+
+    Attributes:
+        min_action: Lower bound of each control amplitude.
+        max_action: Upper bound of each control amplitude.
+        min_obs: Lower bound of the observation space (unbounded).
+        max_obs: Upper bound of the observation space (unbounded).
+        dt: DNS timestep of the integrator.
+        action_time: Physical time simulated per RL step.
+        save_time: Time interval between saved trajectory states.
+        k1, k2, k3, k4: Wavenumbers of the four sinusoidal control modes.
+        action_dim: Number of control amplitudes.
+        obs_dim: Flattened observation size.
+        max_episode_steps: Episode length in RL steps.
+        reward_alpha: Weight of the TKE term in the reward (the action
+            penalty is always weighted at 1).
+        include_grad: Whether gradient information is included (kept for
+            interface compatibility).
+    """
+
     min_action: float = -0.5
     max_action: float = 0.5
     min_obs: float = -jnp.inf
@@ -334,11 +403,30 @@ class KolmogorovFlowParams(EnvParams):
 
 
 class KolmogorovFlow(JAXFlowEnvBase):
+    """2D Kolmogorov-flow Gymnax environment.
+
+    Each RL step rolls the pseudo-spectral Navier-Stokes solver forward for
+    ``action_time`` of physical time with the four sinusoidal control modes
+    derived from the action vector. The observation is the time-mean of the
+    velocity magnitude over the rollout, sampled on an ``obs_size x obs_size``
+    grid; the reward combines the mean turbulent kinetic energy with an
+    L1 penalty on the action.
+    """
+
     def __init__(
         self,
         env_config: Optional[Dict] = None,
         flow_config: Optional[Dict] = None,
     ):
+        """Create the flow configuration, equation, and integrator.
+
+        Args:
+            env_config: Environment options; supports ``dt`` to override the
+                integrator timestep (default: the value in
+                :class:`KolmogorovFlowParams`).
+            flow_config: Options forwarded to :class:`FlowConfig` (``k``,
+                ``Re``, ``grid_size``, ``domain_x``, ``domain_y``, ``obs_size``).
+        """
         super().__init__(env_config)
 
         self.flow = FlowConfig(**(flow_config or {}))
@@ -360,10 +448,16 @@ class KolmogorovFlow(JAXFlowEnvBase):
 
     @property
     def name(self) -> str:
+        """Name of this environment."""
         return "KolmogorovFlow"
 
     @property
     def default_params(self) -> KolmogorovFlowParams:
+        """Default parameters, with ``obs_dim`` from the flow's ``obs_size`` and the optional ``dt`` override applied.
+
+        Returns:
+            A :class:`KolmogorovFlowParams` instance.
+        """
         dt_override = getattr(self, "_dt_override", None)
         kwargs = dict(action_dim=4, obs_dim=self.flow.obs_size**2)
         if dt_override is not None:
@@ -371,6 +465,15 @@ class KolmogorovFlow(JAXFlowEnvBase):
         return KolmogorovFlowParams(**kwargs)
 
     def action_space(self, params: Optional[KolmogorovFlowParams] = None):
+        """Return the (Box) action space bounded by the parameters' action limits.
+
+        Args:
+            params: Environment parameters; defaults to ``self.default_params``.
+
+        Returns:
+            Gymnax Box space of shape ``(params.action_dim,)`` with bounds
+            ``[params.min_action, params.max_action]``.
+        """
         params = params or self.default_params
         return spaces.Box(
             low=params.min_action,
@@ -379,6 +482,15 @@ class KolmogorovFlow(JAXFlowEnvBase):
         )
 
     def observation_space(self, params: KolmogorovFlowParams):
+        """Return the (Box) observation space bounded by the parameters' observation limits.
+
+        Args:
+            params: Environment parameters.
+
+        Returns:
+            Gymnax Box space of shape ``(params.obs_dim,)`` with bounds
+            ``[params.min_obs, params.max_obs]``.
+        """
         return spaces.Box(
             low=params.min_obs,
             high=params.max_obs,
@@ -386,6 +498,19 @@ class KolmogorovFlow(JAXFlowEnvBase):
         )
 
     def _control_field(self, action: jnp.ndarray, params: KolmogorovFlowParams) -> Tuple[jnp.ndarray, jnp.ndarray]:
+        """Convert the action vector into a physical-space forcing field.
+
+        Builds the x-forcing as the sum of four sinusoidal modes in y with
+        amplitudes ``a1..a4`` and wavenumbers ``params.k1..k4``; the y-forcing
+        is zero.
+
+        Args:
+            action: Control amplitudes, shape (4,).
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(forcing_x, forcing_y)`` of physical-space arrays.
+        """
         a1, a2, a3, a4 = action
         forcing_x = (
             a1 * jnp.sin(params.k1 * self.y)
@@ -453,9 +578,29 @@ class KolmogorovFlow(JAXFlowEnvBase):
         params: KolmogorovFlowParams,
         key: Optional[chex.PRNGKey] = None,
     ) -> chex.Array:
+        """Compute the observation as the time-mean velocity magnitude over the rollout.
+
+        Args:
+            state: Current environment state.
+            params: Environment parameters (unused).
+            key: Unused; accepted for API compatibility.
+
+        Returns:
+            Flattened array of shape ``(params.obs_dim,)`` (see
+            :meth:`_trajectory_mean_obs`).
+        """
         return self._trajectory_mean_obs(state.trajectory)
 
     def _avg_tke(self, trajectory: jnp.ndarray) -> jnp.ndarray:
+        """Average the turbulent kinetic energy over a trajectory of spectral vorticity states.
+
+        Args:
+            trajectory: Array of spectral vorticity snapshots with a leading
+                time axis.
+
+        Returns:
+            Scalar mean TKE over all snapshots.
+        """
         def one(omega_hat):
             return compute_tke(omega_hat, self.kx, self.ky, self.n)
 
@@ -467,6 +612,17 @@ class KolmogorovFlow(JAXFlowEnvBase):
         trajectory: jnp.ndarray,
         params: KolmogorovFlowParams,
     ) -> jnp.ndarray:
+        """Compute the reward for a rollout as negative weighted TKE plus an L1 action penalty.
+
+        Args:
+            action: Control amplitudes applied during the rollout.
+            trajectory: Spectral vorticity snapshots produced by the rollout.
+            params: Environment parameters (``reward_alpha`` weights the TKE
+                term; the action penalty has weight 1).
+
+        Returns:
+            Scalar reward ``-(reward_alpha * mean_TKE + sum(|action|))``.
+        """
         energy = self._avg_tke(trajectory)
         action_penalty = jnp.sum(jnp.abs(action))
         return -(params.reward_alpha * energy + action_penalty)
@@ -476,6 +632,19 @@ class KolmogorovFlow(JAXFlowEnvBase):
         key: chex.PRNGKey,
         params: KolmogorovFlowParams,
     ):
+        """Reset the environment: initialize the flow and spin it up unactuated.
+
+        The initial divergence-free vorticity field is generated and rolled out
+        for one ``action_time`` window with no control; the resulting state
+        carries both the final spectral vorticity and the saved trajectory.
+
+        Args:
+            key: PRNG key (unused; the reset is deterministic).
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, KolmogorovFlowState)`` at RL time 0.
+        """
         omega0 = self.flow.initialize_state()
 
         final_state, trajectory = self._rollout(
@@ -500,6 +669,24 @@ class KolmogorovFlow(JAXFlowEnvBase):
         action: chex.Array,
         params: KolmogorovFlowParams,
     ):
+        """Advance the environment by one RL step under the given action.
+
+        The action is clipped to the parameter bounds, converted into a
+        physical-space control field of four sinusoidal modes, and the flow is
+        rolled out for one ``action_time`` window. The observation is the
+        time-mean velocity magnitude over the rollout and the reward is the
+        weighted mean TKE plus the L1 action penalty (negated).
+
+        Args:
+            key: PRNG key (unused; the dynamics are deterministic).
+            state: Current environment state.
+            action: Control amplitudes for the four sinusoidal modes.
+            params: Environment parameters.
+
+        Returns:
+            Tuple ``(obs, next_state, reward, done, info)`` where ``info``
+            contains ``"discount"`` and ``"mean_tke"``.
+        """
         action = self._clip_action(action, params)
         control_field = self._control_field(action, params)
 

--- a/hydrogym/jax/envs/kolmogorov.py
+++ b/hydrogym/jax/envs/kolmogorov.py
@@ -666,6 +666,7 @@ class KolmogorovFlow(JAXFlowEnvBase):
         Returns:
             Scalar mean TKE over all snapshots.
         """
+
         def one(omega_hat):
             """TKE of a single spectral vorticity snapshot."""
             return compute_tke(omega_hat, self.kx, self.ky, self.n)

--- a/hydrogym/jax/envs/kolmogorov.py
+++ b/hydrogym/jax/envs/kolmogorov.py
@@ -78,6 +78,20 @@ class FlowConfig(PDEBase):
         return jnp.meshgrid(x, y, indexing="ij")
 
     def _calculate_velocity_point(self, state, k1, k2):
+        """Evaluate the velocity at a single observation point from a spectral vorticity state.
+
+        Reconstructs the velocity in Fourier space (via
+        :func:`~hydrogym.jax.utils.utils.compute_velocity_fft`) and evaluates
+        the real-space velocity at grid point ``(k1, k2)``.
+
+        Args:
+            state: Spectral vorticity field.
+            k1: x-index of the evaluation point.
+            k2: y-index of the evaluation point.
+
+        Returns:
+            Real-space velocity at that point (2-vector).
+        """
         # Calculate velocity point
         kx, ky = self.load_fft_mesh()
         uhat, vhat = compute_velocity_fft(state, kx, ky)
@@ -104,6 +118,7 @@ class FlowConfig(PDEBase):
         divisor = n // self.obs_size
 
         def calculate_velocity(trajectory):
+            """Evaluate the velocity at every subsampled observation point of one snapshot."""
             points = [
                 self._calculate_velocity_point(trajectory, x, y)
                 for x in range(0, n, int(n / divisor))
@@ -112,6 +127,7 @@ class FlowConfig(PDEBase):
             return jnp.array(points)
 
         def scan_fn(carry, state):
+            """Observation for one trajectory snapshot (the carry is unused)."""
             obs_val = calculate_velocity(state)  # To use energy observation, swap this with calculate_energy
             return carry, obs_val
 
@@ -145,9 +161,11 @@ class FlowConfig(PDEBase):
 
         # Gradients of φ(x,y) #
         def dstream_func_dx(x, y):
+            """x-derivative of the stream function, ``d(phi)/dx = cos(x)``."""
             return jnp.cos(x)
 
         def dstream_func_dy(x, y):
+            """y-derivative of the stream function, ``d(phi)/dy = -sin(y)``."""
             return -jnp.sin(y)
 
         dudy = jax.grad(dstream_func_dy, argnums=1)
@@ -313,10 +331,16 @@ class PseudoSpectralNavierStokes2D(IMEXEquation):
         return self.kx * cfy_hat - self.ky * cfx_hat
 
     def forcing_term(self):
-        """Computes the user-specified forcing term of the vorticity equation
-        Args:
-          omega_hat: Fourier transformed vorticity term
-          forcing: Forcing function as specified by environment or user
+        """Compute the environmental forcing term of the vorticity equation.
+
+        Evaluates the flow's ``forcing_function(k, x, y)`` in physical space,
+        transforms the (fx, fy) velocity forcing to Fourier space, and takes
+        its curl ``2i*pi * (fy_hat * kx - fx_hat * ky)`` to obtain the
+        vorticity-space forcing.
+
+        Returns:
+            The spectral forcing term of the same shape as the state, or
+            ``None`` if the flow defines no forcing function.
         """
         forcing_func = self.flow.forcing_function
         if forcing_func is not None:
@@ -527,9 +551,21 @@ class KolmogorovFlow(JAXFlowEnvBase):
         params: KolmogorovFlowParams,
         control_field: Optional[Tuple[jnp.ndarray, jnp.ndarray]] = None,
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
-        """
+        """Roll the pseudo-spectral solver forward for one ``action_time`` window.
+
+        Uses the integrator built at construction with the default parameters'
+        ``dt`` and ``save_time``.
+
+        Args:
+            omega_hat0: Initial spectral vorticity field.
+            params: Environment parameters (unused; the rollout settings come
+                from ``self.default_params``).
+            control_field: Optional tuple ``(forcing_x, forcing_y)`` of
+                physical-space control fields applied throughout the rollout.
+
         Returns:
-            final_state_hat, trajectory
+            Tuple ``(final_state_hat, trajectory)``: the final spectral
+            vorticity and the stacked saved states along the rollout.
         """
         default = self.default_params
         dt = float(default.dt)
@@ -547,14 +583,43 @@ class KolmogorovFlow(JAXFlowEnvBase):
         return final_state, trajectory
 
     def _calculate_velocity_point(self, omega_hat: jnp.ndarray, i: int, j: int):
+        """Evaluate the real-space velocity at grid point ``(i, j)`` from a spectral vorticity field.
+
+        Uses the precomputed Fourier mesh cached at construction.
+
+        Args:
+            omega_hat: Spectral vorticity field.
+            i: x-index of the evaluation point.
+            j: y-index of the evaluation point.
+
+        Returns:
+            Real-space velocity at that point (2-vector).
+        """
         uhat, vhat = compute_velocity_fft(omega_hat, self.kx, self.ky)
         return compute_real_velocity_point(uhat, vhat, i, j)
 
     def _trajectory_mean_obs(self, trajectory: jnp.ndarray) -> jnp.ndarray:
+        """Compute the time-mean velocity-magnitude observation over a rollout trajectory.
+
+        For each spectral vorticity snapshot the velocity is reconstructed in
+        Fourier space, transformed to physical space on the full grid once,
+        subsampled on a regular ``obs_size x obs_size`` grid (stride
+        ``grid_size // obs_size``, at least 1), converted to velocity
+        magnitude, and finally averaged over the snapshots.
+
+        Args:
+            trajectory: Array of spectral vorticity snapshots with a leading
+                time axis.
+
+        Returns:
+            Flattened array of shape ``(obs_size * obs_size,)`` with the
+            trajectory-mean velocity magnitude at each observation point.
+        """
         stride_x = max(1, self.n // self.flow.obs_size)
         stride_y = max(1, self.m // self.flow.obs_size)
 
         def obs_one_state(omega_hat):
+            """Velocity-magnitude observation (subsampled, flattened) for one spectral state."""
             # 1. Compute velocity in Fourier space for the whole grid ONCE
             uhat, vhat = compute_velocity_fft(omega_hat, self.kx, self.ky)
 
@@ -602,6 +667,7 @@ class KolmogorovFlow(JAXFlowEnvBase):
             Scalar mean TKE over all snapshots.
         """
         def one(omega_hat):
+            """TKE of a single spectral vorticity snapshot."""
             return compute_tke(omega_hat, self.kx, self.ky, self.n)
 
         return jnp.mean(jax.vmap(one)(trajectory))

--- a/hydrogym/jax/equation.py
+++ b/hydrogym/jax/equation.py
@@ -1,33 +1,109 @@
 class Equation:
+    """Base class for a PDE right-hand-side defined on a state vector.
+
+    Subclasses implement the full right-hand side in :meth:`rhs`, either
+    directly or by splitting it into linear and nonlinear parts (see
+    :class:`SplitEquation`).
+    """
+
     def __init__(self, params):
+        """Store the equation parameters.
+
+        Args:
+            params: Solver/equation parameters (interpreted by subclasses).
+        """
         # init stuff
         self.params = params
 
     def rhs(self, state, control):
+        """Evaluate the right-hand side of the equation.
+
+        Args:
+            state: Current state vector.
+            control: Control (actuation) input applied to the flow.
+
+        Returns:
+            Time derivative of the state. Not implemented in the base class.
+        """
         pass
         # calculate linear and non-linear terms
 
 
 class SplitEquation(Equation):
+    """Equation whose right-hand side is split into linear and nonlinear terms.
+
+    The split exists so implicit-explicit (IMEX) time integrators can treat
+    the linear (stiff, typically viscous) term implicitly via
+    :meth:`implicit_timestep` in subclasses, and the nonlinear term explicitly.
+    """
+
     def __init__(self, params):
+        """See :class:`Equation`."""
         super().__init__(params)
 
     def linear_terms(self, state, control):
+        """Evaluate the linear (implicitly treated) term of the equation.
+
+        Args:
+            state: Current state vector.
+            control: Control (actuation) input.
+
+        Returns:
+            Linear contribution to the state derivative. Not implemented here.
+        """
         pass
 
     def nonlinear_terms(self, state, control):
+        """Evaluate the nonlinear (explicitly treated) term of the equation.
+
+        Args:
+            state: Current state vector.
+            control: Control (actuation) input.
+
+        Returns:
+            Nonlinear contribution to the state derivative. Not implemented here.
+        """
         pass
 
     def rhs(self, state, control):
+        """Evaluate the full right-hand side as linear + nonlinear terms.
+
+        Args:
+            state: Current state vector.
+            control: Control (actuation) input.
+
+        Returns:
+            Sum of the linear and nonlinear contributions.
+        """
         return self.linear_terms(state, control) + self.nonlinear_terms(state, control)
 
     def forcing(self):
+        """Evaluate any external forcing added to the right-hand side.
+
+        Not implemented in the base class.
+        """
         pass
 
 
 class IMEXEquation(SplitEquation):
+    """Split equation supporting an implicit linear timestep.
+
+    Intended for IMEX schemes: the linear term is advanced implicitly via
+    :meth:`implicit_timestep` while the nonlinear term is handled explicitly
+    by the integrator.
+    """
+
     def __init__(self, params):
+        """See :class:`SplitEquation`."""
         super().__init__(params)
 
     def implicit_timestep(self, state):
+        """Advance the linear part of the equation implicitly by one timestep.
+
+        Args:
+            state: Current state vector.
+
+        Raises:
+            NotImplementedError: Always; subclasses must define the implicit solve.
+        """
         raise NotImplementedError

--- a/hydrogym/jax/solvers/base.py
+++ b/hydrogym/jax/solvers/base.py
@@ -72,6 +72,18 @@ class RungeKuttaCrankNicolson(TransientSolver):
 
         @tree_math.wrap
         def time_step_fn(u):
+            """Advance a (tree-wrapped) state by one full 5-stage IMEX-RK step.
+
+            Each stage combines the explicit nonlinear term (with the
+            low-storage recursion ``h``) with a partially implicit
+            Crank-Nicolson solve of the linear term.
+
+            Args:
+                u: Current state (tree of arrays).
+
+            Returns:
+                The state after one timestep.
+            """
             h = 0
             for k in range(5):
                 h = unwrapped_nonlinear(u) + _beta_RK4[k] * h
@@ -83,20 +95,30 @@ class RungeKuttaCrankNicolson(TransientSolver):
         return time_step_fn
 
     def step(self, flow: PDEBase, dt: float, save_n: int, callbacks: Callable, control_field=None):
-        """
-        Lax.scan to iteratively apply a function given an initial value
+        """Build a ``lax.scan`` function that advances a state by ``save_n`` timesteps.
+
+        Note this returns the *scan function*, not a stepped state: the caller
+        nests it inside an outer scan (see :meth:`solve`).
 
         Args:
-            initialization(grid array): the initial fft vorticity field
-            steps (int):  number of timesteps
-            save_n (int): save every n steps
-            ignore_intermediate_steps (bool): if saving every n steps, ignore intermediate steps.
-                                              this drastically reduces the memory requirements.
+            flow: Flow configuration (unused here; the equation carries the
+                dynamics).
+            dt: Timestep size (unused here; the one fixed at construction
+                applies).
+            save_n: Number of timesteps each inner scan performs.
+            callbacks: Unused; per-step callback tracking is not possible
+                inside compiled scans.
+            control_field: Optional control input forwarded to the equation's
+                nonlinear terms at every step.
 
+        Returns:
+            Callable mapping an initial state to the state ``save_n``
+            timesteps later.
         """
         func = self.RK4_CN(control_field=control_field)
 
         def inner_scan(initialization):
+            """Run ``save_n`` RK4-CN timesteps from ``initialization``, keeping only the final state."""
             f = lambda init, inputs: (func(init), init)
             final_state, outputs = lax.scan(f, initialization, xs=None, length=save_n)
             return final_state
@@ -230,6 +252,7 @@ class RungeKutta4:
         dt = self.dt if dt is None else dt
 
         def add_state(a, b, alpha=1.0):
+            """Component-wise ``a + alpha * b`` for two :class:`VelocityState` values."""
             return VelocityState(
                 a.u + alpha * b.u,
                 a.v + alpha * b.v,

--- a/hydrogym/jax/solvers/base.py
+++ b/hydrogym/jax/solvers/base.py
@@ -15,13 +15,38 @@ _gammas_RK4 = [0.1496590219993, 0.3792103129999, 0.8229550293869, 0.699450455948
 
 
 class VelocityState(NamedTuple):
+    """Three-component velocity (or velocity-spectrum) state, one array per direction.
+
+    Attributes:
+        u: x-component; physical or spectral depending on usage.
+        v: y-component.
+        w: z-component.
+    """
+
     u: jnp.ndarray  # physical or spectral depending on usage
     v: jnp.ndarray
     w: jnp.ndarray
 
 
 class RungeKuttaCrankNicolson(TransientSolver):
+    """IMEX Crank-Nicolson Runge-Kutta transient solver for a split equation.
+
+    Advances an :class:`~hydrogym.jax.equation.IMEXEquation` with the nonlinear
+    terms treated explicitly and the linear terms treated implicitly, using a
+    low-storage 5-stage scheme; the whole rollout is expressed as a
+    ``lax.scan`` so it can be JIT-compiled.
+    """
+
     def __init__(self, flow: PDEBase, dt: float, save_n: int, equation: IMEXEquation, **kwargs):
+        """Initialize the solver.
+
+        Args:
+            flow: Flow configuration providing the state (used by the base class).
+            dt: Timestep size.
+            save_n: Number of (inner) steps between saved states.
+            equation: The split (IMEX) equation being integrated.
+            **kwargs: Ignored; accepted for API compatibility.
+        """
         self.save_n = save_n
         self.dt = dt
         self.flow = flow
@@ -89,6 +114,35 @@ class RungeKuttaCrankNicolson(TransientSolver):
         initial_state=None,
         control_field=None,
     ) -> PDEBase:
+        """Integrate the equation from t=0 to ``t_span[1]`` with nested lax scans.
+
+        The rollout is run as an outer scan of inner scans, each of ``save_n // dt``
+        timesteps, so the saved trajectory holds one state per ``save_n`` time
+        units. Callbacks are invoked once at the end (per-iteration callback
+        tracking is not possible through the compiled scans).
+
+        Args:
+            dt: Timestep size.
+            flow: Flow configuration; also supplies the initial state when
+                ``initial_state`` is None.
+            t_span: ``(t0, t1)`` integration interval; ``t1`` must be at least 1.
+            callbacks: Callbacks invoked on the flow after the rollout.
+            controller: Unused; accepted for API compatibility with the
+                hydrogym solver interface.
+            save_n: Time interval between saved trajectory states.
+            initial_state: Optional starting state (FFT vorticity field);
+                defaults to ``flow.initialize_state()``.
+            control_field: Optional control input forwarded to the equation's
+                nonlinear terms at every step.
+
+        Returns:
+            Tuple ``(final_state, outputs)`` where ``outputs`` is the stacked
+            trajectory of states at each outer-scan step (also stored on
+            ``flow.vorticity``).
+
+        Raises:
+            ValueError: If the end time in ``t_span`` is less than 1.
+        """
         end_time = t_span[1]
         if end_time < 1:
             raise ValueError(
@@ -116,7 +170,26 @@ class RungeKuttaCrankNicolson(TransientSolver):
 
 
 class RungeKutta4:
+    """Explicit classical 4th-order Runge-Kutta stepper for a velocity state.
+
+    Each step evaluates the equation's full right-hand side four times,
+    projects the result back onto the constraint manifold
+    (``equation.project``), and optionally applies a constant-mass-flux
+    correction by rescaling the mean streamwise velocity in physical space
+    before re-applying the boundary conditions.
+    """
+
     def __init__(self, equation, dt: float, save_n: int, **kwargs):
+        """Initialize the integrator.
+
+        Args:
+            equation: Equation object providing ``rhs``, ``project``,
+                ``to_physical``, ``to_spectral`` and ``enforce_noslip``.
+            dt: Default timestep used when ``rk4_step`` gets no explicit ``dt``.
+            save_n: Number of steps between saves (stored; not used by
+                ``rk4_step`` itself).
+            **kwargs: Ignored; accepted for API compatibility.
+        """
         self.save_n = int(save_n)
         self.dt = dt
         self.equation = equation
@@ -133,6 +206,26 @@ class RungeKutta4:
         enforce_const_massflux=True,
         target_bulk_u=8.0,
     ):
+        """Advance the state by one RK4 step, then project and correct mass flux.
+
+        Args:
+            state_hat: Current state (spectral velocity components).
+            dt: Timestep; defaults to the value given at construction.
+            action: Control (actuation) input forwarded to the equation's rhs,
+                projection, and boundary-condition enforcement.
+            t: Current time, used for time-dependent BCs and forcing.
+            fx: x-direction body forcing.
+            fy: y-direction body forcing.
+            fz: z-direction body forcing.
+            enforce_const_massflux: If True, rescale the streamwise velocity in
+                physical space so the bulk velocity equals ``target_bulk_u``,
+                then re-apply the no-slip/jet boundary conditions.
+            target_bulk_u: Target bulk (domain-mean) streamwise velocity for
+                the mass-flux correction.
+
+        Returns:
+            The new state in spectral form.
+        """
         eq = self.equation
         dt = self.dt if dt is None else dt
 

--- a/hydrogym/jaxfluids/env_core.py
+++ b/hydrogym/jaxfluids/env_core.py
@@ -34,6 +34,15 @@ class JAXFluidsFlowEnv(HFEnvConfigMixin, JAXFluidsEnv):
     HF_CACHE_NAMESPACE = "jaxfluidsgym"
 
     def _init_from_hf(self, env_config: dict) -> None:
+        """Initialize HF-backed environment data from ``env_config``.
+
+        Reads the HF settings (``hf_repo_id``, ``local_fallback_dir``,
+        ``use_clean_cache``, ``hf_token``, ``hf_revision``) and constructs
+        this env's :class:`~hydrogym.data_manager.HFDataManager` instance.
+
+        Args:
+            env_config: Environment configuration dict.
+        """
         # Initialize HF data manager
         self.hf_repo_id = env_config.get("hf_repo_id", "dynamicslab/HydroGym-environments")
         self.local_fallback_dir = env_config.get("local_fallback_dir", None)

--- a/hydrogym/nek/env.py
+++ b/hydrogym/nek/env.py
@@ -1192,6 +1192,13 @@ class RingBuffer:
     """N-dimensional ring buffer using numpy arrays."""
 
     def __init__(self, length, dim=1):
+        """Allocate the backing array.
+
+        Args:
+            length: Number of entries the buffer holds before wrapping.
+            dim: Shape of each entry (an int, or a tuple of axis sizes);
+                defaults to scalar entries.
+        """
         if type(dim) is int:
             dim = (dim,)
         self.data = np.zeros((length,) + dim, dtype="f")

--- a/test/measure_docstrings.py
+++ b/test/measure_docstrings.py
@@ -29,6 +29,15 @@ DEFAULT_TARGETS = [
     "hydrogym/jax/solvers/base.py",
     "hydrogym/jax/envs/channel.py",
     "hydrogym/jax/envs/kolmogorov.py",
+    # Additional files the audit's Finding-4 table measured but that were
+    # omitted from the original target list. (hydrogym/nek/integrate.py is
+    # deliberately omitted — under concurrent edit at measurement time.)
+    "hydrogym/data_manager.py",
+    "hydrogym/hf_env_mixin.py",
+    "hydrogym/core_external.py",
+    "hydrogym/nek/env.py",
+    "hydrogym/maia/env_core.py",
+    "hydrogym/jaxfluids/env_core.py",
 ]
 
 

--- a/test/measure_docstrings.py
+++ b/test/measure_docstrings.py
@@ -51,7 +51,15 @@ def measure(path):
 
 def main():
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    targets = sys.argv[1:] or DEFAULT_TARGETS
+    # --fail-under <pct> sets a CI exit-code gate on the TOTAL coverage;
+    # everything else is treated as explicit file targets.
+    fail_under = None
+    args = list(sys.argv[1:])
+    if "--fail-under" in args:
+        i = args.index("--fail-under")
+        fail_under = float(args[i + 1])
+        del args[i : i + 2]
+    targets = args or DEFAULT_TARGETS
     grand_have = grand_total = 0
     for t in targets:
         p = t if os.path.isabs(t) else os.path.join(root, t)
@@ -63,8 +71,18 @@ def main():
         grand_total += total
         pct = 100 * have / total if total else 100.0
         print(f"{t:50s} {have:3d}/{total:<3d} {pct:6.1f}%")
-    if grand_total:
-        print(f"{'TOTAL':50s} {grand_have:3d}/{grand_total:<3d} {100 * grand_have / grand_total:6.1f}%")
+    if not grand_total:
+        return
+    total_pct = 100 * grand_have / grand_total
+    print(f"{'TOTAL':50s} {grand_have:3d}/{grand_total:<3d} {total_pct:6.1f}%")
+    if fail_under is not None:
+        if total_pct < fail_under:
+            print(
+                f"FAIL: docstring coverage {total_pct:.1f}% is below the "
+                f"{fail_under:.1f}% floor (audit Task 7.2)"
+            )
+            sys.exit(1)
+        print(f"OK: docstring coverage at or above the {fail_under:.1f}% floor")
 
 
 if __name__ == "__main__":

--- a/test/measure_docstrings.py
+++ b/test/measure_docstrings.py
@@ -77,10 +77,7 @@ def main():
     print(f"{'TOTAL':50s} {grand_have:3d}/{grand_total:<3d} {total_pct:6.1f}%")
     if fail_under is not None:
         if total_pct < fail_under:
-            print(
-                f"FAIL: docstring coverage {total_pct:.1f}% is below the "
-                f"{fail_under:.1f}% floor (audit Task 7.2)"
-            )
+            print(f"FAIL: docstring coverage {total_pct:.1f}% is below the {fail_under:.1f}% floor (audit Task 7.2)")
             sys.exit(1)
         print(f"OK: docstring coverage at or above the {fail_under:.1f}% floor")
 

--- a/test/measure_docstrings.py
+++ b/test/measure_docstrings.py
@@ -1,0 +1,62 @@
+"""Measure docstring coverage (audit Task 7.1) — dev-only helper, not a test.
+
+Method mirrors the audit: ast.get_docstring over every module-level and
+nested class/function definition. Run inside a container:
+
+    python test/measure_docstrings.py [file1.py file2.py ...]
+
+With no args, measures the audit's target set.
+"""
+
+import ast
+import os
+import sys
+
+DEFAULT_TARGETS = [
+    "hydrogym/core.py",
+    "hydrogym/firedrake/flow.py",
+    "hydrogym/firedrake/actuator.py",
+    "hydrogym/firedrake/solvers/base.py",
+    "hydrogym/firedrake/solvers/bdf_ext.py",
+    "hydrogym/firedrake/solvers/integrate.py",
+    "hydrogym/firedrake/solvers/stabilization.py",
+    "hydrogym/firedrake/envs/cavity/flow.py",
+    "hydrogym/firedrake/envs/cylinder/flow.py",
+    "hydrogym/firedrake/envs/pinball/flow.py",
+    "hydrogym/firedrake/envs/step/flow.py",
+    "hydrogym/jax/env_core.py",
+    "hydrogym/jax/equation.py",
+    "hydrogym/jax/solvers/base.py",
+    "hydrogym/jax/envs/channel.py",
+    "hydrogym/jax/envs/kolmogorov.py",
+]
+
+
+def measure(path):
+    tree = ast.parse(open(path).read())
+    nodes = [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))]
+    total = len(nodes)
+    have = sum(1 for n in nodes if ast.get_docstring(n))
+    return have, total
+
+
+def main():
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    targets = sys.argv[1:] or DEFAULT_TARGETS
+    grand_have = grand_total = 0
+    for t in targets:
+        p = t if os.path.isabs(t) else os.path.join(root, t)
+        if not os.path.exists(p):
+            print(f"{t:50s} MISSING")
+            continue
+        have, total = measure(p)
+        grand_have += have
+        grand_total += total
+        pct = 100 * have / total if total else 100.0
+        print(f"{t:50s} {have:3d}/{total:<3d} {pct:6.1f}%")
+    if grand_total:
+        print(f"{'TOTAL':50s} {grand_have:3d}/{grand_total:<3d} {100 * grand_have / grand_total:6.1f}%")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Seventh PR in the sequential \`hydrogym-audit-v2\` stack. Targets #288 (Phase 5/6).

## Scope (Phase 7 — docstring coverage)

- Add \`test/measure_docstrings.py\`, a small AST-based coverage tool
  (counts public classes/functions/methods with a docstring vs without,
  per file and in total)
- Roll out missing docstrings across \`core.py\`, the Firedrake backend,
  the JAX backend, and the remaining lower-coverage files
- Task 7.2: wire the tool into CI as a coverage floor (99%) and close
  the final private-helper gaps

## Verified

- \`ruff check .\`, \`ruff format --check .\`, \`isort . --check-only --diff\`,
  codespell all clean (added a follow-up commit for 2 formatting findings)
- \`python test/measure_docstrings.py --fail-under 99\` run live at the
  tip of this chunk: **454/454 (100.0%)**, floor satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)