### PR TITLE
gym.make() as the unified entry point across all backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,28 @@ budget and catch `NekDivergenceError` for Nek physics failure.
   - `hydrogym.jaxfluids.envs` never re-exported its environment classes
     (unlike every other backend's `envs` package), and `registration.py`
     never defaulted `environment_name` — both fixed.
+- `hydrogym/firedrake/utils/modeling.py::linearize_dynamics` called
+  `NewtonSolver.steady_form()` with an un-split `fd.Function`, but
+  `steady_form` immediately unpacks its argument as `(u, p) = q`,
+  expecting the already-split tuple `NewtonSolver.solve()` itself
+  provides via `fd.split(q)`. Raised `ValueError: too many values to
+  unpack`; previously masked because the only caller
+  (`test_cyl.py::test_linearize`) always diverged before reaching this
+  code path (see the `test_steady` checkpoint-ambiguity fix below, which
+  applies to `test_linearize` too).
+- `docs/docs/api/` (generated via `pydoc-markdown`) had drifted from
+  source: a stale NEK5000 default environment name
+  (`MiniChannel_Re180`, which doesn't exist), missing pages for modules
+  added this cycle, and stale pages for removed modules. Regenerated;
+  also fixed `hydrogym/registration.py`'s module docstring, whose bare
+  `import ...`-leading code example broke Docusaurus's MDX build once
+  regenerated (rewritten as a proper `Examples:`/`>>>` block).
+- `examples/nek/getting_started/README.md`: sections 2 and 3 documented
+  a nonexistent factory call and (for section 3) claimed
+  `NekPettingZooEnv` implements PettingZoo's turn-based AEC interface —
+  it is actually a `pettingzoo.ParallelEnv` subclass, same dict-based,
+  simultaneous-action shape as section 2. Both fixed and live-verified
+  against real MPMD Nek5000 runs.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,20 @@ budget and catch `NekDivergenceError` for Nek physics failure.
   defines `WARNING`) — any checkpoint-resolution error that should have
   logged a warning and fallen back gracefully instead crashed with an
   unrelated `AttributeError`.
+- `gym.make(...)` was broken for 2 of the 3 non-Firedrake gymnasium-API
+  backends, and for Firedrake's own zero-argument case:
+  - `SemiImplicitBDF` required `dt` positionally, contradicting its own
+    parent classes' documented "defaults to `flow.DEFAULT_DT`" contract
+    — broke every registered Firedrake ID's default construction.
+  - MAIA's `gym.make()` path imported `hydrogym.maia.env_core` directly,
+    bypassing the lazy loader that registers environment classes —
+    `from_hf()` always saw an empty registry. Fixed, plus MAIA now raises
+    a clear `ConfigError` (not a crash) when `probe_locations` is missing,
+    and `hydrogym-maia/Cylinder_2D_Re200-v0` ships a verified default
+    probe grid so it works with zero extra arguments.
+  - `hydrogym.jaxfluids.envs` never re-exported its environment classes
+    (unlike every other backend's `envs` package), and `registration.py`
+    never defaulted `environment_name` — both fixed.
 
 ### Removed
 

--- a/HYDROGYM_ENGINEERING_AUDIT_v2.md
+++ b/HYDROGYM_ENGINEERING_AUDIT_v2.md
@@ -2501,3 +2501,174 @@ affected by it.
 
 Commits: `4eb509d` (SemiImplicitBDF), `73b0f95` (MAIA + JAX-Fluids),
 `09de9dc` (CHANGELOG).
+
+## Making `gym.make()` the Documented Standard, Closing Remaining Findings (2026-09-05)
+
+Follow-up to the previous section: with `gym.make()` verified working
+across all four gymnasium-API backends, this pass (1) made it the
+documented, discoverable standard entry point everywhere a user would
+first look, (2) added it as an explicit, tested feature rather than an
+implementation detail, and (3) used the "run everything, don't assert"
+directive to find and fix issues the previous passes missed.
+
+### Documentation changes
+
+Every backend README (main `README.md`, `examples/firedrake/README.md`,
+`examples/maia/README.md`, `examples/nek/getting_started/README.md`,
+`examples/jax/README.md`) now leads with `gym.make()` as the standard
+entry point and demotes native construction (`FlowEnv`, `.from_hf()`,
+direct `NekEnv`/`MaiaFlowEnv` construction) to explicitly-labeled
+lower-level side entries, matching the mujoco/gymnasium convention the
+user asked for. `docs/docs/quickstart.md` and `docs/docs/introduction.md`
+got the same treatment. `examples/jaxfluids/README.md` didn't exist
+before this pass and was added.
+
+Four reference scripts (`examples/{firedrake,maia,nek,jaxfluids}/
+getting_started/gym_make_demo.py`, and one at `examples/jaxfluids/
+gym_make_demo.py`), each live-verified end-to-end (Firedrake in-process;
+MAIA and Nek as real MPMD jobs; JAX-Fluids in-process), are the canonical
+examples every README's `gym.make()` section points to.
+
+### `gym.make()` added as an explicit, tested feature
+
+`test/test_registration_live.py` (new) exercises `gym.make()` against the
+**real** Firedrake backend (no mocking) for all 5 registered ids, plus a
+kwarg-override test — this is the actual regression coverage for the
+feature, since the pre-existing `test/test_registration.py` mocks every
+backend and therefore cannot catch backend-integration bugs (see the
+previous section's four real bugs it never caught).
+
+### Nek5000 README: two structurally wrong sections found and fixed
+
+Running every example against the "test and prove it" standard surfaced
+that `examples/nek/getting_started/README.md`'s sections 2 and 3 had
+fundamentally wrong, not-just-cosmetic API usage:
+
+- **Section 2 (`2_parallel_env`)**: documented a nonexistent factory
+  call (`parallel_env(environment_name=..., nproc=..., num_agents=...)`)
+  and `obs = env.reset()` (single return value). The real API is
+  composition — construct `NekEnv` first, then wrap it —
+  and `reset()` returns `(obs, info)`. Fixed and live-verified (real
+  10-rank MPMD run, 400 agents, exit 0).
+- **Section 3 (`3_pettingzoo`)**: this was worse than a typo — the
+  section's title ("PettingZoo AEC Interface"), use-case description
+  ("Turn-based multi-agent scenarios"), and code (`env.agent_iter()`/
+  `env.last()`) all claimed `NekPettingZooEnv` implements PettingZoo's
+  turn-based AEC protocol. Reading `hydrogym/nek/pettingzoo_env.py` in
+  full shows `class NekPettingZooEnv(ParallelEnv)` — it is a
+  `pettingzoo.ParallelEnv` subclass, i.e. the same dict-based,
+  simultaneous-action interface as section 2's `NekParallelEnv`, just
+  with PettingZoo-spec compliance (`metadata`, cached
+  `observation_space`/`action_space`) added on top. Confirmed the
+  `agent_iter()` snippet does not even run
+  (`AttributeError: 'NekPettingZooEnv' object has no attribute
+  'agent_iter'`) before rewriting the section to accurately describe it
+  as a `ParallelEnv`-compliance wrapper, not an AEC interface. Re-verified
+  live against a real 10-rank MPMD job after the fix (400 agents, exit 0)
+  using the existing `3_pettingzoo/test_nek_pettingzoo.py`, which already
+  used the correct dict-based pattern — only the README was wrong.
+  Also removed an unused `from pettingzoo.utils import parallel_to_aec`
+  import left in `train_sb3_pettingzoo.py` from the same earlier,
+  incorrect AEC-based design; the script actually wraps the `ParallelEnv`
+  directly with `supersuit.pettingzoo_env_to_vec_env_v1`.
+
+### API docs (`docs/docs/api/`) had drifted badly and needed regeneration
+
+Grepping for stale references (`hgym.IPCS`, old factory calls,
+`MiniChannel_Re180`) turned up two real problems in the checked-in,
+auto-generated `docs/docs/api/*.md` files:
+
+1. `docs/docs/api/nek/__init__.md` and `docs/docs/api/nek/env.md` still
+   showed `NekEnv.from_hf('MiniChannel_Re180', ...)` — an environment
+   name that does not exist (fixed in the *source* docstring by an
+   earlier commit in this session, `db3ee88`, but the generated docs were
+   never regenerated afterward).
+2. Diffing a full regeneration (`pydoc-markdown` via `docs/package.json`'s
+   `generate-api` script) against the checked-in docs showed the drift
+   was much larger than just this one string: entire modules added this
+   session (`registration.py`, `core_external.py`, `bdf_ext.py`,
+   `hf_env_mixin.py`, `jax/equation.py`) had no doc page at all, and two
+   modules removed earlier (`maia/hf_data_manager.py`, `jax/flow.py`)
+   still had stale pages.
+
+Regenerating surfaced a second, independent bug: `hydrogym/registration.py`'s
+module docstring used a bare indented code block starting with
+`import hydrogym.registration`. pydoc-markdown's `google`-style processor
+doesn't preserve that as a fenced code block, so the generated
+`docs/docs/api/registration.md` had a raw `import ...` line outside any
+code fence — Docusaurus's MDX compiler tries to parse any top-level line
+starting with `import`/`export` as a real ESM statement and failed the
+build (`Could not parse import/exports with acorn`). Confirmed by running
+`docusaurus build` (Node 20, since the repo requires it and the host only
+had Node 18 — downloaded a portable Node 20 build to verify). Fixed by
+rewriting the docstring's example as an `Examples:`/`>>>` doctest-style
+block, the convention already used elsewhere in this codebase (e.g.
+`maia/env_core.py::from_hf`) and confirmed to render correctly. Full site
+build verified clean after the fix and the full doc regeneration.
+
+### Two more real bugs found while re-running the full Firedrake suite
+
+Re-running `test/`'s full suite after all the above (`pytest . --ignore
+test_*_grad.py`, the repo's own CI invocation) surfaced one failure not
+caught by the previous pass's targeted Finding-C fixes:
+
+- **`test_cyl.py::test_linearize`**: same root cause as `test_steady`
+  (Finding C) — `hgym.Cylinder(mesh="medium")` without
+  `use_HF_data_manager=False` picks up a nondeterministically-selected
+  transient checkpoint as the Newton solve's initial guess, which
+  diverges. This specific test was missed by the earlier sweep because it
+  doesn't assert on force coefficients (just exercises
+  `solver.solve()` + `hgym.modeling.linearize()`), so it wasn't part of
+  the numerical-target audit. Fixed identically to `test_steady`.
+- Fixing that initial-condition issue let the Newton solve converge far
+  enough to reach `hgym.modeling.linearize()` for the first time in this
+  audit, which then surfaced a **second, independent, previously-masked
+  bug**: `hydrogym/firedrake/utils/modeling.py::linearize_dynamics` calls
+  `solver.steady_form(q=qB)` with the raw, un-split `qB` `fd.Function`,
+  but `NewtonSolver.steady_form` immediately unpacks its argument as
+  `(u, p) = q`, expecting the already-split tuple that
+  `NewtonSolver.solve()` itself provides via `fd.split(q)`. This raised
+  `ValueError: too many values to unpack` and had presumably never been
+  exercised successfully before, since the only caller
+  (`test_cyl.py::test_linearize`) always diverged before reaching it.
+  Fixed by calling `fd.split(qB)` before `steady_form()`, matching
+  `NewtonSolver.solve()`'s own usage. Verified live: `test_linearize`
+  passes end-to-end (steady solve, then forward and adjoint
+  linearization) both standalone and under pytest.
+
+**Devcontainer resync gotcha, worth recording**: the CPU test container
+(`jovial_proskuriakova`) bind-mounts a *separate* clone
+(`/home/christian/test_hydrogym_devcontainer/hydrogym`) from this
+session's working clone, tracked via a `local` git remote pointing at the
+working clone's path. It had drifted 3 commits behind mid-session, so a
+`pytest test_cyl.py::test_linearize` run inside it was silently exercising
+stale, pre-fix source (still showing the ConvergenceError from before the
+`use_HF_data_manager=False` fix, even though the fix had already been
+committed on the working clone) — resolved with `git fetch local
+<branch> && git merge --ff-only local/<branch>` inside that clone, plus a
+direct file copy for the not-yet-committed edit-in-progress. Always
+confirm `git log -1`/`git diff <file>` match between the working clone and
+whatever container is about to run verification before trusting a
+"still fails" result.
+
+### "Delete stale/deprecated examples" — investigated, nothing found
+
+Searched for backup-named files (`*.bak`, `*deprecated*`, `*.old`) and
+grepped for known-stale API references (`hgym.IPCS`, old `parallel_env(`
+factory calls, `parallel_to_aec`, `MiniChannel_Re180`) across
+`examples/`, `docs/`, and the main `README.md`. No dead/backup files
+exist; every stale reference found was fixed in place rather than
+deleted (see above) since each corresponded to a real, currently-used
+example script that just needed its documentation or a small bug
+corrected, not removal.
+
+### Full Firedrake test suite: final result
+
+`pytest test/ --ignore test_cavity_grad.py --ignore test_pinball_grad.py
+--ignore test_step_grad.py` (the repo's own CI invocation), re-run after
+all fixes above: **all tests pass** (previously 236 passed / 1 failed / 6
+skipped; the 1 failure was `test_linearize`, now fixed and passing).
+
+Commits: `a8a47c2` (READMEs/quickstart/introduction), `aa5e8ce` (API docs
+regeneration + registration.py docstring fix + dead-import cleanup),
+`acf979a` (test_linearize + linearize_dynamics fixes).

--- a/HYDROGYM_ENGINEERING_AUDIT_v2.md
+++ b/HYDROGYM_ENGINEERING_AUDIT_v2.md
@@ -2387,3 +2387,117 @@ Fortran solver-internal behavior this repo doesn't own the source for,
 the other needs profiling this pass wasn't scoped to do. Nothing found in
 this pass touches the MPI/launch architecture question from the prior
 pass; that finding stands as previously confirmed.
+
+---
+
+## `gym.make()` as a Unified Entry Point (2026-09-05)
+
+**Trigger:** a direct follow-up question — is `gym.make("hydrogym/...")`
+(the mujoco/gymnasium convention: one call, `.reset()`/`.step()` work the
+same regardless of backend, lower-level entry points preserved for
+advanced use) genuinely achievable with the current implementation? Task
+6.1's `hydrogym.registration` module (§ Proposed Target Architecture item
+6 of the original audit) was built for exactly this, but had never
+actually been exercised end-to-end against real backends — every existing
+test of it (`test/test_registration.py`) mocks the backend entirely, so
+the dispatch *logic* was tested but the real construction path never was.
+It wasn't working. Three real bugs, one per non-Firedrake gymnasium-API
+backend, plus a fourth that broke Firedrake's own zero-argument case —
+found only by actually calling `gym.make(...)` against live backends, not
+by reading the code, and each confirmed live before and after the fix:
+
+1. **`SemiImplicitBDF` required `dt` positionally**, contradicting its own
+   parent classes' (`TransientSolver`, `NavierStokesTransientSolver`)
+   documented contract that `dt` defaults to the flow's `DEFAULT_DT` when
+   omitted (every flow class defines one specifically for this). Broke
+   `gym.make()` for all 5 registered Firedrake IDs unconditionally, and —
+   traced after the fact — turned out to be the exact same root cause
+   behind 2 of the "6 unrelated pre-existing failures" the previous
+   Examples Verification pass had flagged as out-of-scope
+   (`test_pinball.py::test_env`, `test_step.py::test_env`); both now pass
+   with no test changes. Fixed: `dt: float = None`, matching the parent
+   signature (`dt` is only ever forwarded, never used directly, so this
+   changes nothing for callers that do pass it).
+2. **MAIA's factory imported `hydrogym.maia.env_core` directly**,
+   bypassing `hydrogym.maia`'s own lazy `__getattr__` loader — the *only*
+   thing that ever imports `hydrogym/maia/envs/*.py`, and each of those
+   files' own module-level `register_environment(...)` call is the only
+   place any environment type ever reaches `_ENVIRONMENT_REGISTRY`.
+   Net effect: `from_hf()` reached through `gym.make()` always saw an
+   empty registry. Outside MPMD this raised immediately; **inside MPMD it
+   was worse** — confirmed live, a real `maia` process pinned at 99% CPU
+   for 6+ minutes with zero progress, because the Python side raised and
+   exited while the paired MAIA rank was already waiting for a handshake
+   that would now never arrive (exactly the MPMD partial-failure mode the
+   dev-tools' own docs elsewhere warn about). Fixed by importing via
+   package attribute access (`import hydrogym.maia as maia`), which
+   correctly triggers the lazy loader.
+3. **MAIA's `probe_locations` had no default and nothing checked for
+   `None`** before use — every registered MAIA ID crashed with
+   `TypeError: object of type 'NoneType' has no len()` even after fixing
+   (2). There is no universal sensible default (the probe grid is a
+   per-flow-geometry choice); `MaiaFlowEnv` now raises a clear
+   `ConfigError` naming what's needed, matching the precedent already set
+   by Nek's required `nproc`. `Cylinder_2D_Re200` gets a verified,
+   working default probe grid in `registration.py` (the wake-sampling
+   grid already used and re-verified many times this session in
+   `test_maia_env.py`), so it now works with **zero** extra arguments.
+   `RotaryCylinder_2D_Re1000`/`Cavity_2D_Re4140` deliberately get no
+   invented default — no verified-safe grid exists for either, and
+   guessing one would risk silently-wrong physics rather than a clear
+   error, which is the worse failure mode.
+4. **`hydrogym.jaxfluids.envs.__init__.py` was empty** — unlike every
+   other backend's `envs` package (Firedrake's re-exports
+   `Cylinder`/`Cavity`/`Pinball`/`Step`), it never re-exported
+   `Nozzle2D`/`Nozzle3D`, so `registration.py`'s `getattr(jxf_envs,
+   "Nozzle2D")` always raised `AttributeError` even though the class
+   existed at `hydrogym.jaxfluids.envs.nozzle.Nozzle2D`. Fixed to match
+   the established convention. Separately, `environment_name` was never
+   defaulted at all — there is no plain `"Nozzle2D"` HF environment, only
+   resolution-suffixed variants (`Nozzle2D_coarse`/`_fine`, confirmed via
+   `HfApi().list_repo_files`); now defaults to `_coarse`, matching
+   `examples/jaxfluids/test_jaxfluids_env.py`'s own default.
+
+**Verified live, after all four fixes, zero-argument `gym.make()` except
+where a real config requirement genuinely exists** (Nek's `nproc`, which
+must match the MPMD launch's worker count; MAIA's two IDs with no
+verified-safe probe default):
+- `gym.make("hydrogym/{Cylinder,RotaryCylinder,Cavity,Pinball,Step}-v0")` —
+  all 5, real Firedrake construction, real `reset()`/`step()`, sensible
+  rewards.
+- `gym.make("hydrogym-maia/Cylinder_2D_Re200-v0")` — real MPMD (`mpirun
+  -np 1 python ... : -np 1 maia ...`), real `reset()`/`step()`, clean
+  close, **zero extra arguments**.
+- `gym.make("hydrogym-nek/TCFmini_3D_Re180-v0", nproc=10)` — real MPMD
+  (`... : -np 10 nek5000`), real `reset()`/`step()`, clean close.
+- `gym.make("hydrogym-jaxfluids/Nozzle2D-v0")` — real JAX-Fluids
+  construction, real `reset()`/`step()`.
+- `gym.make("hydrogym/Cylinder-v0")` was also cross-checked against
+  the actual `test/test_registration.py` file: `test_pinball.py::test_env`/
+  `test_step.py::test_env` (independent evidence for fix 1) now pass.
+
+**Answering the actual question**: yes, `gym.make(id, **kwargs)` is now a
+genuine, working, mujoco/gymnasium-style unified entry point across every
+gymnasium-API backend (Firedrake, MAIA, Nek, JAX-Fluids — JAX remains
+deliberately unregistered, functional/JIT contract, see the original
+audit's Solver Interface Design). One call, `.reset()`/`.step()` behave
+identically regardless of what's happening underneath (in-process,
+MPMD, or otherwise), and every backend's own lower-level entry point
+(`hydrogym.firedrake.Cylinder`+`FlowEnv` directly, `hydrogym.maia.from_hf`,
+`NekEnv.from_hf`, the JAX-Fluids env classes directly, `hydrogym.jax`'s
+functional API) remains fully available and untouched — `gym.make()` is a
+thin, additive layer over them, not a replacement.
+
+**One honest caveat, not fixed, matching the previous pass's own
+precedent for out-of-scope pre-existing issues**: two of
+`test_registration.py`'s existing mocked tests (and one new one added
+here) fail when run as part of specific multi-file test combinations,
+while passing individually — the same test-order-dependent cross-test
+state leakage already documented in the Examples Verification pass as a
+pre-existing, unrelated issue. It affects the *mocked unit tests'*
+hermeticity only; the real, live, non-mocked `gym.make()` runs above are
+the actual correctness evidence for this section, and none of them are
+affected by it.
+
+Commits: `4eb509d` (SemiImplicitBDF), `73b0f95` (MAIA + JAX-Fluids),
+`09de9dc` (CHANGELOG).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,71 @@ HydroGym is a comprehensive platform for applying reinforcement learning to flui
 - **2D & 3D**: From simple 2D benchmarks to complex 3D turbulent flows (Re up to 400,000)
 - **Research-Ready**: Managed by a complementary HuggingFace repository
 
+## Quick Start: `gym.make()`
+
+**The standard way to start any HydroGym environment is gymnasium's
+`gym.make()`** — one call, the same shape regardless of backend:
+
+```python
+import gymnasium as gym
+import hydrogym.registration  # registers HydroGym's environment ids
+
+env = gym.make("hydrogym/Cylinder-v0")
+obs, info = env.reset()
+for _ in range(100):
+    action = env.action_space.sample()
+    obs, reward, terminated, truncated, info = env.step(action)
+env.close()
+```
+
+The exact same shape works for every gymnasium-API backend — only the id
+(and, for MAIA/Nek, the MPMD launch command underneath) changes:
+
+| Backend | id | Launch |
+|---|---|---|
+| Firedrake | `hydrogym/Cylinder-v0`, `RotaryCylinder`, `Cavity`, `Pinball`, `Step` | `python script.py` |
+| MAIA | `hydrogym-maia/Cylinder_2D_Re200-v0` (zero extra args) | `mpirun -np 1 python script.py : -np N maia properties_run.toml` |
+| NEK5000 | `hydrogym-nek/TCFmini_3D_Re180-v0` (`nproc=` required) | `mpirun -np 1 python script.py : -np N nek5000` |
+| JAX-Fluids | `hydrogym-jaxfluids/Nozzle2D-v0`, `Nozzle3D` | `python script.py` |
+
+Runnable, verified reference scripts for each: [`examples/firedrake/getting_started/gym_make_demo.py`](examples/firedrake/getting_started/gym_make_demo.py),
+[`examples/maia/getting_started/gym_make_demo.py`](examples/maia/getting_started/gym_make_demo.py),
+[`examples/nek/getting_started/gym_make_demo.py`](examples/nek/getting_started/gym_make_demo.py),
+[`examples/jaxfluids/gym_make_demo.py`](examples/jaxfluids/gym_make_demo.py).
+
+`gym.make()` is additive, not a cage — pass `env_config={...}` (Firedrake,
+JAX-Fluids) or backend-native kwargs (MAIA, Nek) to override any default,
+same as constructing the environment directly. MAIA ids other than
+`Cylinder_2D_Re200` have no universal default probe grid and require
+`probe_locations=[...]`; `gym.make()` raises a clear error naming this if
+it's missing, rather than guessing at flow-geometry-specific defaults.
+
+**JAX stays outside `gym.make()` by design.** It implements a
+functional/JIT (`gymnax`-style) contract — `jax.jit(env.reset_env)` /
+`jax.jit(env.step_env)`, not `gymnasium.Env`'s `reset()`/`step()` — because
+the whole point of the JAX backend is being traceable through
+`jax.jit`/`jax.vmap`/`jax.lax.scan`, which a `self`-mutating
+`gymnasium.Env` cannot be. Wrapping it in `gym.make()` would present a
+misleading API. Use `hydrogym.jax.envs.*` directly — see
+[`examples/jax/getting_started/`](examples/jax/getting_started/).
+
+### Lower-level entry points
+
+`gym.make()` is a thin, optional layer over each backend's own native
+construction path — every one of them remains fully available, for direct
+solver access, open-loop control, custom flow/solver classes, or anything
+`gym.make()`'s registered defaults don't cover:
+
+- **Firedrake**: `hydrogym.firedrake.Cylinder` + `hydrogym.core.FlowEnv`
+  directly, or `hydrogym.firedrake.NewtonSolver`/`SemiImplicitBDF` on a
+  bare flow object for non-RL workflows (steady-state solves, stability
+  analysis) — see [`examples/firedrake/advanced/`](examples/firedrake/advanced/).
+- **MAIA**: `hydrogym.maia.from_hf(...)` — see [`examples/maia/getting_started/test_maia_env.py`](examples/maia/getting_started/test_maia_env.py).
+- **NEK5000**: `hydrogym.nek.NekEnv.from_hf(...)` / `NekEnv(env_config=...)` — see [`examples/nek/getting_started/`](examples/nek/getting_started/).
+- **JAX-Fluids**: `hydrogym.jaxfluids.envs.Nozzle2D(env_config=...)` directly.
+- **JAX**: the functional API is always the entry point (there is no
+  higher-level wrapper to bypass) — see [`examples/jax/getting_started/`](examples/jax/getting_started/).
+
 ## Quick Start with Docker (Recommended)
 
 **We strongly recommend using our pre-configured Docker containers** for hassle-free setup:
@@ -89,7 +154,12 @@ All required environment checkpoints are available via [HuggingFace](https://hug
 
 ## Examples
 
-HydroGym includes comprehensive examples for each solver backend (internet connection required). We highly recommend using our provided docker containers:
+HydroGym includes comprehensive examples for each solver backend (internet connection required). We highly recommend using our provided docker containers.
+Each backend's `getting_started/` directory includes a `gym_make_demo.py`
+(the standard entry point above) alongside the backend-specific,
+lower-level scripts below (direct construction, SB3 training loops,
+multi-agent wrappers) — start with `gym_make_demo.py` unless you need
+what a specific lower-level script demonstrates.
 
 ### Firedrake Examples
 
@@ -162,24 +232,25 @@ cd 3_ppo
 
 ## Training RL Agents
 
-HydroGym works with standard RL libraries. Example with Stable-Baselines3:
+HydroGym works with standard RL libraries. Example with Stable-Baselines3,
+built on `gym.make()`:
 
 ```python
-from hydrogym import FlowEnv
-import hydrogym.firedrake as hgym
+import gymnasium as gym
+import hydrogym.registration
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
 
-# Create environment
+# Create environment (env_config overrides gym.make()'s registered defaults)
 def make_env():
-    env_config = {
-        'flow': hgym.Cylinder,
-        'flow_config': {'mesh': 'medium', 'Re': 100},
-        'solver': hgym.SemiImplicitBDF,
-        'solver_config': {'dt': 1e-2},
-        'actuation_config': {'num_substeps': 2},
-    }
-    return FlowEnv(env_config)
+    return gym.make(
+        "hydrogym/Cylinder-v0",
+        env_config={
+            "flow_config": {"mesh": "medium", "Re": 100},
+            "solver_config": {"dt": 1e-2},
+            "actuation_config": {"num_substeps": 2},
+        },
+    )
 
 # Vectorize and normalize
 env = DummyVecEnv([make_env])
@@ -190,7 +261,12 @@ model = PPO("MlpPolicy", env, verbose=1)
 model.learn(total_timesteps=100000)
 ```
 
-See also provided [examples/](examples/) for more details how to leverage individual solver backends for training.
+Constructing `hydrogym.core.FlowEnv`/backend-native factories
+(`hydrogym.maia.from_hf`, `NekEnv.from_hf`, ...) directly works exactly
+the same way and remains fully supported — `gym.make()` is a thin,
+optional layer on top, not a replacement; see "Lower-level entry points"
+above. See also provided [examples/](examples/) for more details how to
+leverage individual solver backends for training.
 
 ## Advanced Features
 

--- a/docs/docs/api/core.md
+++ b/docs/docs/api/core.md
@@ -9,6 +9,57 @@ title: hydrogym.core
 class ActuatorBase()
 ```
 
+Base class for a single actuator driving the flow.
+
+An actuator holds a scalar state ``x`` that the controller updates each
+step. Subclasses override :meth:`step` to define how the applied state
+evolves from the requested input (e.g. first-order smoothing towards the
+input over the flow&#x27;s ``TAU`` timescale) rather than setting it directly.
+
+**Attributes**:
+
+- `x` - Current actuator state.
+
+#### \_\_init\_\_
+
+```python
+def __init__(state=0.0, **kwargs)
+```
+
+Initialize the actuator to a constant state.
+
+**Arguments**:
+
+- `state` - Initial actuator state. Defaults to 0.0.
+- `**kwargs` - Ignored; accepted so subclasses can pass through
+  shared configuration dictionaries unchanged.
+
+#### state
+
+```python
+@property
+def state() -> float
+```
+
+Return the current actuator state.
+
+**Returns**:
+
+- `float` - Current value of the actuator state ``x``.
+
+#### state
+
+```python
+@state.setter
+def state(u: float)
+```
+
+Set the actuator state directly.
+
+**Arguments**:
+
+- `u` _float_ - New actuator state.
+
 #### step
 
 ```python
@@ -28,6 +79,39 @@ Basic configuration of the state of the PDE model
 Will contain any time-varying flow fields, boundary
 conditions, actuation models, etc. Does not contain
 any information about solving the time-varying equations
+
+#### \_\_init\_\_
+
+```python
+def __init__(**config)
+```
+
+Configure the PDE from keyword arguments and prepare it for use.
+
+Loads the mesh, initializes the state, and resets the model to its
+initial condition. Also handles the ``restart`` option: a single
+checkpoint path (string) is loaded immediately, while a list/tuple of
+paths loads the first one as the default state (FlowEnv handles
+random selection among the full set at reset time).
+
+Subclasses are expected to ``.pop`` their own config keys before
+calling ``super().__init__``; any keys left in ``config`` at this
+point are almost certainly typos or unsupported options, so a
+warning is emitted rather than silently ignoring them.
+
+**Arguments**:
+
+- `**config` - Configuration options. PDEBase itself consumes:
+  - mesh (str): Mesh name passed to ``load_mesh``.
+  Defaults to ``DEFAULT_MESH``.
+  - restart (str | list | tuple): Checkpoint file(s) to load.
+  Defaults to None (start from the initial condition).
+  
+
+**Raises**:
+
+- ``3 - If ``restart`` is neither a string nor a list/tuple
+  of strings.
 
 #### num\_inputs
 
@@ -142,6 +226,33 @@ def collect_bcs() -> Iterable[BCType]
 
 Return the set of boundary conditions
 
+#### save\_checkpoint
+
+```python
+@abc.abstractmethod
+def save_checkpoint(filename: str)
+```
+
+Write the current PDE state to a checkpoint file.
+
+**Arguments**:
+
+- `filename` _str_ - Path of the checkpoint file to write.
+
+#### load\_checkpoint
+
+```python
+@abc.abstractmethod
+def load_checkpoint(filename: str)
+```
+
+Load the PDE state from a checkpoint file.
+
+**Arguments**:
+
+- `filename` _str_ - Path of a checkpoint previously written by
+  ``save_checkpoint``.
+
 #### get\_observations
 
 ```python
@@ -178,6 +289,15 @@ def enlist(x: Any) -> Iterable[Any]
 ```
 
 Convert scalar or array-like to a list
+
+#### control\_state
+
+```python
+@property
+def control_state() -> Iterable[ArrayLike]
+```
+
+Return the current control vector (one entry per actuator).
 
 #### set\_control
 
@@ -231,20 +351,23 @@ Plot the current PDE state (called by `gymnasium.Env`)
 class CallbackBase()
 ```
 
+Base class for things that happen every so often in the simulation.
+
+Concrete callbacks (e.g. saving output for visualization or writing log
+entries) are invoked by ``TransientSolver.solve`` each iteration; the
+default ``__call__`` acts only every ``interval`` iterations.
+
+TODO: Add a ControllerCallback
+
 #### \_\_init\_\_
 
 ```python
 def __init__(interval: int = 1)
 ```
 
-Base class for things that happen every so often in the simulation
-(e.g. save output for visualization or write some info to a log file).
-
 **Arguments**:
 
 - `interval` _int, optional_ - How often to take action. Defaults to 1.
-  
-- `TODO` - Add a ControllerCallback
 
 #### \_\_call\_\_
 
@@ -280,6 +403,20 @@ class TransientSolver()
 ```
 
 Time-stepping code for updating the transient PDE
+
+#### \_\_init\_\_
+
+```python
+def __init__(flow: PDEBase, dt: float = None)
+```
+
+Bind the solver to a flow and select the time step.
+
+**Arguments**:
+
+- `flow` _PDEBase_ - The PDE model to be time-stepped.
+- `dt` _float, optional_ - Time step to use. Defaults to the flow&#x27;s
+  ``DEFAULT_DT`` if not given.
 
 #### solve
 
@@ -346,6 +483,87 @@ Reset variables for the timestepper
 class FlowEnv(gym.Env)
 ```
 
+Gymnasium environment wrapping a PDE model and its transient solver.
+
+Each ``step`` advances the flow and returns the (negated, time-scaled)
+objective as the reward. Reaching the configured step budget is reported
+as a truncation, not a termination. Optionally, one ``step`` can advance
+the simulation by several solver substeps while holding the action
+constant, with per-substep rewards aggregated by a configurable rule.
+
+**Attributes**:
+
+- `flow` - The underlying PDE model.
+- `solver` - The transient solver driving the PDE.
+- `callbacks` - Callbacks invoked after each step.
+- `max_steps` - Episode length in environment steps.
+- `iter` - Total number of solver steps taken since the last reset.
+- `num_substeps` - Solver steps per environment step.
+- ``0 - How per-substep objectives are combined
+  (&#x27;mean&#x27;, &#x27;sum&#x27;, or &#x27;median&#x27;).
+- ``1 - List of checkpoint paths (if any) available
+  for random selection on reset, else None.
+- ``2 - Preloaded flow states to reset to.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env_config: dict)
+```
+
+Build the flow and solver from ``env_config`` and set up spaces.
+
+Multi-substep actuation is configured via ``actuation_config``. The
+old keys ``num_sim_substeps_per_actuation`` and
+``reward_aggreation_rule`` (misspelled) are still accepted but emit a
+DeprecationWarning; their non-deprecated replacements are
+``num_substeps`` and ``reward_aggregation``.
+
+The ``restart`` entry of ``flow_config`` selects the initial states:
+a string means a single checkpoint (already loaded by the flow), a
+list/tuple means several checkpoints, all of which are preloaded as
+candidate initial states (reset picks one at random).
+
+**Arguments**:
+
+- ``6 _dict_ - Configuration dictionary containing:
+  - flow (type): Callable (usually a PDEBase subclass)
+  constructing the flow from ``flow_config``.
+  - flow_config (dict, optional): Keyword configuration passed
+  to the flow constructor.
+  - solver (type): Callable (usually a TransientSolver
+  subclass) constructing the solver as
+  ``solver(flow, **solver_config)``.
+  - solver_config (dict, optional): Keyword configuration
+  passed to the solver.
+  - callbacks (Iterable[CallbackBase], optional): Callbacks
+  invoked after each step. Defaults to [].
+  - max_steps (int, optional): Steps per episode. Defaults to
+  1e6.
+  - actuation_config (dict, optional): Multi-substep options
+  (see above). Defaults to one substep and &#x27;mean&#x27;
+  aggregation.
+  
+
+**Raises**:
+
+- ``1 - If ``num_substeps &lt; 1``, if ``reward_aggregation``
+  is not &#x27;mean&#x27;, &#x27;sum&#x27;, or &#x27;median&#x27;, or if ``restart`` is
+  neither a string nor a list/tuple.
+
+#### set\_callbacks
+
+```python
+def set_callbacks(callbacks: Iterable[CallbackBase])
+```
+
+Replace the environment&#x27;s callbacks.
+
+**Arguments**:
+
+- `callbacks` _Iterable[CallbackBase]_ - Callbacks to invoke after
+  each step.
+
 #### step
 
 ```python
@@ -382,6 +600,33 @@ Convert observations to numpy array format.
 
 - `np.ndarray` - Observations as a numpy array
 
+#### get\_reward
+
+```python
+def get_reward()
+```
+
+Return the reward for the current flow state.
+
+The reward is the negative of the flow&#x27;s objective function (which
+is to be minimized), scaled by the solver time step.
+
+**Returns**:
+
+- `float` - Reward ``-dt * evaluate_objective()``.
+
+#### check\_complete
+
+```python
+def check_complete()
+```
+
+Check whether the episode has exceeded its step budget.
+
+**Returns**:
+
+- `bool` - True if the number of elapsed steps exceeds ``max_steps``.
+
 #### reset
 
 ```python
@@ -399,4 +644,27 @@ Reset the environment to initial state.
 **Returns**:
 
   Tuple[ArrayLike, dict]: (observation, info)
+
+#### render
+
+```python
+def render(mode="human", **kwargs)
+```
+
+Render the current PDE state.
+
+**Arguments**:
+
+- `mode` _str, optional_ - Render mode passed through to the flow.
+  Defaults to &quot;human&quot;.
+- `**kwargs` - Additional keyword arguments forwarded to
+  ``flow.render``.
+
+#### close
+
+```python
+def close()
+```
+
+Close the environment by closing all registered callbacks.
 

--- a/docs/docs/api/core_external.md
+++ b/docs/docs/api/core_external.md
@@ -1,0 +1,96 @@
+---
+sidebar_label: core_external
+title: hydrogym.core_external
+---
+
+Shared MPMD communicator setup for external-process backends (audit Task 3.5).
+
+The Nek and MAIA backends both talk to their CFD solver as a separate MPI
+application launched in the same MPMD world (``mpirun -n 1 python ... :
+-n N ./solver``). Each previously owned a private copy of the world-split
+logic:
+
+- ``hydrogym.nek.env.mpi_split`` -- rank-color split (rank 0 = controller,
+ranks 1+ = workers) followed by ``Create_intercomm``; validates the
+world size against the expected worker count.
+- ``hydrogym.maia.mpmd_interface.MaiaInterface.init_comm`` -- APPNUM-based
+split (true MPMD, any controller rank count), with group-translation +
+Allreduce discovery of the remote application&#x27;s root rank.
+
+The two are genuinely different split strategies (not copies), so this
+module hosts each verbatim as a named function and adds
+`ExternalProcessEnvMixin` as the common extension point carrying the
+protocol knobs (controller rank, intercomm tag, log prefix). Per-solver
+tag-protocol code (the actual command/data messages) stays untouched in
+each backend.
+
+Callers:
+- NekEnv (mixin ``_split_mpmd_comm``); ``hydrogym.nek.env.mpi_split`` is
+re-exported from here so ``hydrogym.nek.mpi_split`` and the
+``monkeypatch.setattr(nek_env_mod, &quot;mpi_split&quot;, ...)`` test idiom keep
+working.
+- ``MaiaInterface.init_comm`` delegates its communicator setup to
+``split_comm_by_appnum`` and assigns the results.
+
+#### mpi\_split
+
+```python
+def mpi_split(comm_world: "MPI.Comm",
+              nproc: Optional[int] = None,
+              controller_rank: int = 0,
+              intercomm_tag: int = 99,
+              log_prefix: str = "[MPI_SPLIT] ") -> "MPI.Comm"
+```
+
+Split the MPMD world into a controller/worker inter-communicator
+(Nek protocol: rank 0 is the controller, ranks 1+ are the workers).
+
+**Arguments**:
+
+- `comm_world` - MPI communicator (typically MPI.COMM_WORLD)
+- `nproc` - Expected number of solver workers (for validation)
+- `controller_rank` - World rank of the controller (default 0)
+- `intercomm_tag` - MPI tag for the inter-communicator handshake
+- `log_prefix` - Prefix for the split log lines
+  
+
+**Returns**:
+
+  Inter-communicator between controller and workers
+
+#### split\_comm\_by\_appnum
+
+```python
+def split_comm_by_appnum(
+    comm_world: "MPI.Comm"
+) -> Tuple[int, "MPI.Comm", int, int, "MPI.Group", int, int]
+```
+
+Split the MPMD world by application number (MAIA protocol: works for
+any controller rank count; the remote application&#x27;s root is discovered
+via group translation + Allreduce).
+
+**Arguments**:
+
+- `comm_world` - MPI communicator, typically MPI.COMM_WORLD.
+  
+
+**Returns**:
+
+  Tuple of (appnum, appComm, appRank, appNoRanks, appGroup,
+  appRootInWorld, remoteRoot) for MaiaInterface to assign.
+
+## ExternalProcessEnvMixin Objects
+
+```python
+class ExternalProcessEnvMixin()
+```
+
+Mixin for environments whose CFD solver runs as a separate MPI
+application in the same MPMD world.
+
+Class attributes (override per backend):
+CONTROLLER_RANK: world rank of the RL controller app (default 0)
+INTERCOMM_TAG: tag for the inter-communicator handshake (default 99)
+MPI_SPLIT_LOG_PREFIX: prefix for split log lines (default &quot;[MPI_SPLIT] &quot;)
+

--- a/docs/docs/api/data_manager.md
+++ b/docs/docs/api/data_manager.md
@@ -75,7 +75,9 @@ def __init__(repo_id: str = "dynamicslab/HydroGym-environments",
              cache_dir: Optional[str] = None,
              local_fallback_dir: Optional[str] = None,
              use_clean_cache: Union[bool, str] = True,
-             fallback_profile: str = "MAIA_LB")
+             fallback_profile: str = "MAIA_LB",
+             token: Optional[str] = None,
+             revision: Optional[str] = None)
 ```
 
 Initialize the HF Data Manager.
@@ -85,17 +87,26 @@ Initialize the HF Data Manager.
 - `repo_id` - Hugging Face repository ID.
 - `cache_dir` - Clean local cache directory (default: ``~/.cache/hydrogym``).
   Only used for HF downloads; local_fallback_dir is used directly.
+  When explicitly set, it is also passed to ``snapshot_download`` so
+  the raw HF download cache lands under it instead of the
+  huggingface_hub default (~/.cache/huggingface).
 - `local_fallback_dir` - Local directory with environment files used when HF
   is unreachable. When available, used directly without cache layer.
   use_clean_cache:
   - ``True``:    Create symlinks into HF cache (recommended).
   - ``&#x27;copy&#x27;``:  Copy files to clean cache.
   - ``False``:   Use HF cache paths directly.
-- `cache_dir`1 - cache_dir is only used for HF downloads, not for local_fallback.
-- `cache_dir`2 - Solver profile to use when no sentinel file is found.
+- `cache_dir`3 - cache_dir is only used for HF downloads, not for local_fallback.
+- `cache_dir`4 - Solver profile to use when no sentinel file is found.
   Defaults to ``&#x27;MAIA_LB&#x27;``.  Pass the environment class&#x27;s
   ``SOLVER_TYPE`` attribute to get the right fallback in offline /
   legacy scenarios.
+- `cache_dir`9 - Hugging Face access token, for private/gated repos. ``None``
+  (default) preserves ambient authentication (``HF_TOKEN`` env var
+  or ``huggingface-cli login``).
+- ``6 - Git revision (branch name, tag, or commit hash) to pin
+  downloads and file listings to. ``None`` (default) uses the
+  repo&#x27;s default branch.
 
 #### get\_available\_environments
 

--- a/docs/docs/api/firedrake/actuator.md
+++ b/docs/docs/api/firedrake/actuator.md
@@ -25,11 +25,57 @@ Since only the ratio k/m enters the dynamics as a time scale tau = m/k, we can
 think of the dynamics as a low-pass filter with a time constant tau.  The single
 remaining parameter is named `damping`, and corresponds to k/m = 1/tau.
 
+#### \_\_init\_\_
+
+```python
+def __init__(damping: float, state: float = 0.0)
+```
+
+Initialize the actuator.
+
+**Arguments**:
+
+- `damping` _float_ - Damping coefficient ``k/m = 1/tau``, i.e. the
+  inverse time constant of the low-pass filter.
+- `state` _float, optional_ - Initial actuator state. Default 0.0.
+
+#### state
+
+```python
+@property
+def state() -> np.ndarray
+```
+
+Current actuator state as a scalar value.
+
+#### state
+
+```python
+@state.setter
+def state(u: float)
+```
+
+Set the actuator state directly.
+
+**Arguments**:
+
+- `u` _float_ - New state value.
+
 #### step
 
 ```python
 def step(u: float, dt: float)
 ```
 
-Update the state of the actuator
+Advance the actuator state by ``dt`` with control input ``u``.
+
+Applies the exact zero-order-hold solution of the first-order
+damped dynamics: ``x &lt;- u + (x - u) * exp(-alpha * dt)``, and
+annotates the update for use with Firedrake/Pyadjoint
+differentiable programming.
+
+**Arguments**:
+
+- `u` _float_ - Control input (target state) held over the step.
+- `dt` _float_ - Time step size.
 

--- a/docs/docs/api/firedrake/envs/cavity/flow.md
+++ b/docs/docs/api/firedrake/envs/cavity/flow.md
@@ -9,6 +9,15 @@ title: hydrogym.firedrake.envs.cavity.flow
 class Cavity(FlowConfig)
 ```
 
+Open cavity flow configuration (Re 7500).
+
+Rectangular open cavity with inflow on the left, free-slip top, and a
+blowing/suction actuator on the leading edge whose velocity profile
+follows Barbagallo et al (2009). The default observation is the
+integral wall-normal shear stress at the trailing edge, and the
+objective is the fluctuation kinetic energy relative to a stored base
+flow ``qB`` (hence ``FUNCTIONS = (&quot;q&quot;, &quot;qB&quot;)``).
+
 #### FUNCTIONS
 
 This flow needs a base flow to compute fluctuation KE
@@ -17,6 +26,102 @@ This flow needs a base flow to compute fluctuation KE
 
 Time constant for controller damping (0.01*instability frequency)
 
+#### num\_inputs
+
+```python
+@property
+def num_inputs() -> int
+```
+
+Number of control inputs: one (blowing/suction on the leading edge).
+
+#### configure\_observations
+
+```python
+def configure_observations(obs_type=None,
+                           probe_obs_types=`{}`) -> ObservationFunction
+```
+
+Select the observation function for the cavity.
+
+**Arguments**:
+
+- `obs_type` _str, optional_ - Observation type. Defaults to
+  &quot;stress_sensor&quot;. Probe-based types passed in
+  ``probe_obs_types`` are also supported.
+- `probe_obs_types` _dict, optional_ - Probe-based observation
+  functions provided by ``FlowConfig``.
+  
+
+**Returns**:
+
+- `ObservationFunction` - The selected observation function.
+  
+
+**Raises**:
+
+- `ValueError` - If ``obs_type`` is not a supported type.
+
+#### init\_bcs
+
+```python
+def init_bcs(function_spaces=None)
+```
+
+Construct and apply the cavity boundary conditions.
+
+Creates the inflow, freestream, no-slip wall, free-slip top, and
+outflow conditions, plus the time-varying leading-edge actuation
+boundary condition (stored in ``bcu_actuation`` as a
+``ScaledDirichletBC``), then applies the current control state.
+
+**Arguments**:
+
+- `function_spaces` _optional_ - Pair of (velocity, pressure)
+  spaces to build conditions on; defaults to the subspaces
+  of the mixed space.
+
+#### collect\_bcu
+
+```python
+def collect_bcu()
+```
+
+List of velocity boundary conditions (inflow, freestream, walls, slip, actuation).
+
+**Returns**:
+
+- `list` - All velocity ``DirichletBC`` objects for this flow.
+
+#### collect\_bcp
+
+```python
+def collect_bcp()
+```
+
+List of pressure boundary conditions.
+
+**Returns**:
+
+- `list` - Pressure ``DirichletBC`` objects (zero pressure at the outlet).
+
+#### linearize\_bcs
+
+```python
+def linearize_bcs(function_spaces=None)
+```
+
+Set boundary conditions to zero-amplitude for linearized problems.
+
+Resets the controls to zero (which scales the actuation BC to
+zero), reinitializes the boundary conditions, and sets the inflow
+velocity to zero.
+
+**Arguments**:
+
+- `function_spaces` _optional_ - Pair of (velocity, pressure)
+  spaces to rebuild the conditions on.
+
 #### wall\_stress\_sensor
 
 ```python
@@ -24,4 +129,44 @@ def wall_stress_sensor(q=None)
 ```
 
 Integral of wall-normal shear stress (see Barbagallo et al, 2009)
+
+#### evaluate\_objective
+
+```python
+def evaluate_objective(q=None, qB=None)
+```
+
+Compute the fluctuation kinetic energy relative to a base flow.
+
+**Arguments**:
+
+- `q` _fd.Function, optional_ - Flow state to evaluate; defaults to
+  the current state.
+- `qB` _fd.Function, optional_ - Base flow to subtract; defaults to
+  the stored base flow ``self.qB``.
+  
+
+**Returns**:
+
+- `float` - ``0.5 * ||u - uB||_L2^2`` of the velocity fields.
+
+#### render
+
+```python
+def render(mode="human", clim=None, levels=None, cmap="RdBu", **kwargs)
+```
+
+Render the current vorticity field with matplotlib.
+
+**Arguments**:
+
+- `mode` _str, optional_ - Rendering mode; only &quot;human&quot; plotting is
+  implemented.
+- `clim` _tuple, optional_ - (min, max) color limits for the
+  vorticity plot. Default (-10, 10).
+- `levels` _array, optional_ - Contour levels; defaults to 20
+  levels spanning ``clim``.
+- `cmap` _str, optional_ - Matplotlib colormap name. Default &quot;RdBu&quot;.
+- `**kwargs` - Additional keyword arguments passed to
+  ``tricontourf``.
 

--- a/docs/docs/api/firedrake/envs/cylinder/flow.md
+++ b/docs/docs/api/firedrake/envs/cylinder/flow.md
@@ -9,9 +9,72 @@ title: hydrogym.firedrake.envs.cylinder.flow
 class CylinderBase(FlowConfig)
 ```
 
+Base class for circular-cylinder flow configurations (Re 100).
+
+Uniform inflow from the left with symmetry conditions top and bottom,
+outflow on the right, and a single rotary/blowing-suction actuator on
+the cylinder wall implemented as a ``ScaledDirichletBC`` driven by
+``cyl_velocity_field`` (subclasses define the velocity profile).
+Default observations are the lift and drag coefficients.
+
 #### TAU
 
 Time constant for controller damping (0.01*vortex shedding period)
+
+#### num\_inputs
+
+```python
+@property
+def num_inputs() -> int
+```
+
+Number of control inputs: one (rotary control on the cylinder).
+
+#### configure\_observations
+
+```python
+def configure_observations(obs_type=None,
+                           probe_obs_types=`{}`) -> ObservationFunction
+```
+
+Select the observation function for the cylinder.
+
+**Arguments**:
+
+- `obs_type` _str, optional_ - Observation type. Defaults to
+  &quot;lift_drag&quot;. Probe-based types passed in
+  ``probe_obs_types`` are also supported.
+- `probe_obs_types` _dict, optional_ - Probe-based observation
+  functions provided by ``FlowConfig``.
+  
+
+**Returns**:
+
+- `ObservationFunction` - The selected observation function.
+  
+
+**Raises**:
+
+- `ValueError` - If ``obs_type`` is not a supported type.
+
+#### init\_bcs
+
+```python
+def init_bcs(function_spaces=None)
+```
+
+Construct and apply the cylinder boundary conditions.
+
+Creates the inflow, freestream (symmetry), and outflow conditions,
+plus the time-varying actuation boundary condition on the cylinder
+wall (``ScaledDirichletBC`` with the subclass&#x27;s
+``cyl_velocity_field``), then applies the current control state.
+
+**Arguments**:
+
+- `function_spaces` _optional_ - Pair of (velocity, pressure)
+  spaces to build conditions on; defaults to the subspaces
+  of the mixed space.
 
 #### cyl\_velocity\_field
 
@@ -20,7 +83,37 @@ Time constant for controller damping (0.01*vortex shedding period)
 def cyl_velocity_field()
 ```
 
-Velocity vector for boundary condition
+Velocity vector for the actuation boundary condition on the cylinder.
+
+**Raises**:
+
+- `NotImplementedError` - In the base class; subclasses must
+  override this.
+
+#### collect\_bcu
+
+```python
+def collect_bcu() -> list[fd.DirichletBC]
+```
+
+List of velocity boundary conditions (inflow, freestream, actuation).
+
+**Returns**:
+
+- `list[fd.DirichletBC]` - All velocity ``DirichletBC`` objects.
+
+#### collect\_bcp
+
+```python
+def collect_bcp() -> list[fd.DirichletBC]
+```
+
+List of pressure boundary conditions.
+
+**Returns**:
+
+- `list[fd.DirichletBC]` - Pressure ``DirichletBC`` objects (zero
+  pressure at the outlet).
 
 #### compute\_forces
 
@@ -61,6 +154,23 @@ http://www.homepages.ucl.ac.uk/~uceseug/Fluids2/Notes_Viscosity.pdf
 
 - `float` - Tangential shear force
 
+#### linearize\_bcs
+
+```python
+def linearize_bcs(function_spaces=None)
+```
+
+Set boundary conditions to zero-amplitude for linearized problems.
+
+Resets the controls to zero (which scales the actuation BC to
+zero) and sets the inflow velocity and freestream condition to
+zero.
+
+**Arguments**:
+
+- `function_spaces` _optional_ - Pair of (velocity, pressure)
+  spaces to rebuild the conditions on.
+
 #### evaluate\_objective
 
 ```python
@@ -69,11 +179,64 @@ def evaluate_objective(q: fd.Function = None) -> float
 
 The objective function for this flow is the drag coefficient
 
+#### render
+
+```python
+def render(mode="human", clim=None, levels=None, cmap="RdBu", **kwargs)
+```
+
+Render the current vorticity field with the cylinder overlaid.
+
+**Arguments**:
+
+- `mode` _str, optional_ - Rendering mode; only &quot;human&quot; plotting is
+  implemented.
+- `clim` _tuple, optional_ - (min, max) color limits for the
+  vorticity plot. Default (-2, 2).
+- `levels` _array, optional_ - Contour levels; defaults to 10
+  levels spanning ``clim``.
+- `cmap` _str, optional_ - Matplotlib colormap name. Default &quot;RdBu&quot;.
+- `**kwargs` - Additional keyword arguments passed to
+  ``tricontourf``.
+
+## RotaryCylinder Objects
+
+```python
+class RotaryCylinder(CylinderBase)
+```
+
+Cylinder controlled by tangential (rotary) blowing on the wall.
+
+The actuation boundary condition is a purely tangential velocity field
+of constant magnitude around the cylinder, so scaling it with the
+control input implements rotational forcing.
+
+#### cyl\_velocity\_field
+
+```python
+@property
+def cyl_velocity_field()
+```
+
+Tangential velocity vector field around the cylinder surface.
+
+**Returns**:
+
+- `ufl.Tensor` - Unit-magnitude tangential velocity
+  ``(-rad * sin(theta), rad * cos(theta))`` as a function of the
+  angle ``theta`` from the cylinder center.
+
 ## Cylinder Objects
 
 ```python
 class Cylinder(CylinderBase)
 ```
+
+Cylinder controlled by normal blowing/suction jets on the wall.
+
+Two jets centered at the top and bottom of the cylinder follow
+Rabault et al (2018), https://arxiv.org/abs/1808.07664, with a 10-degree
+angular width each; the actuation BC is scaled by the control input.
 
 #### cyl\_velocity\_field
 
@@ -86,4 +249,10 @@ Velocity vector for boundary condition
 
 Blowing/suction actuation on the cylinder wall, following Rabault, et al (2018)
 https://arxiv.org/abs/1808.07664
+
+**Returns**:
+
+- `ufl.Tensor` - Normal (radial) velocity field on the cylinder
+  wall, nonzero only within the jet widths around the top and
+  bottom of the cylinder.
 

--- a/docs/docs/api/firedrake/envs/pinball/flow.md
+++ b/docs/docs/api/firedrake/envs/pinball/flow.md
@@ -9,6 +9,13 @@ title: hydrogym.firedrake.envs.pinball.flow
 class Pinball(FlowConfig)
 ```
 
+Flow over three cylinders in a triangular &quot;pinball&quot; arrangement (Re 30).
+
+Uniform inflow with symmetry conditions top and bottom, and one rotary
+(tangential) actuator per cylinder, so the number of control inputs is
+three. The default observation is the six lift/drag coefficients (one
+lift-drag pair per cylinder) and the objective is the total drag.
+
 #### MAX\_CONTROL
 
 TODO: Limit this based on literature
@@ -16,4 +23,180 @@ TODO: Limit this based on literature
 #### TAU
 
 TODO: Tune this based on vortex shedding period
+
+#### init\_bcs
+
+```python
+def init_bcs(function_spaces=None)
+```
+
+Construct and apply the pinball boundary conditions.
+
+Creates the inflow, freestream (symmetry), and outflow conditions,
+plus one tangential (rotary) actuation boundary condition per
+cylinder (each a ``ScaledDirichletBC`` scaled by the corresponding
+control input), then applies the current control state.
+
+**Arguments**:
+
+- `function_spaces` _optional_ - Pair of (velocity, pressure)
+  spaces to build conditions on; defaults to the subspaces
+  of the mixed space.
+
+#### num\_inputs
+
+```python
+@property
+def num_inputs() -> int
+```
+
+Number of control inputs: one rotary actuator per cylinder (three).
+
+#### configure\_observations
+
+```python
+def configure_observations(obs_type=None,
+                           probe_obs_types=`{}`) -> ObservationFunction
+```
+
+Select the observation function for the pinball.
+
+**Arguments**:
+
+- `obs_type` _str, optional_ - Observation type. Defaults to
+  &quot;lift_drag&quot;. Probe-based types passed in
+  ``probe_obs_types`` are also supported.
+- `probe_obs_types` _dict, optional_ - Probe-based observation
+  functions provided by ``FlowConfig``.
+  
+
+**Returns**:
+
+- `ObservationFunction` - The selected observation function.
+  
+
+**Raises**:
+
+- `ValueError` - If ``obs_type`` is not a supported type.
+
+#### collect\_bcu
+
+```python
+def collect_bcu() -> Iterable[fd.DirichletBC]
+```
+
+List of velocity boundary conditions (inflow, freestream, actuation).
+
+**Returns**:
+
+- `Iterable[fd.DirichletBC]` - All velocity ``DirichletBC`` objects,
+  one actuation BC per cylinder.
+
+#### collect\_bcp
+
+```python
+def collect_bcp() -> Iterable[fd.DirichletBC]
+```
+
+List of pressure boundary conditions.
+
+**Returns**:
+
+- `Iterable[fd.DirichletBC]` - Pressure ``DirichletBC`` objects
+  (zero pressure at the outlet).
+
+#### compute\_forces
+
+```python
+def compute_forces(q: fd.Function = None) -> Iterable[float]
+```
+
+Compute dimensionless lift/drag coefficients on each cylinder.
+
+**Arguments**:
+
+- `q` _fd.Function, optional_ - Flow state to compute forces from;
+  defaults to the current state.
+  
+
+**Returns**:
+
+- `Iterable[float]` - Pair of lists ``(CL, CD)`` with one lift and
+  one drag value per cylinder, ordered as ``CYLINDER``.
+
+#### linearize\_bcs
+
+```python
+def linearize_bcs(function_spaces=None)
+```
+
+Set boundary conditions to zero-amplitude for linearized problems.
+
+Resets the controls to zero (which scales the actuation BCs to
+zero), reinitializes the boundary conditions, and sets the inflow
+velocity and freestream condition to zero.
+
+**Arguments**:
+
+- `function_spaces` _optional_ - Pair of (velocity, pressure)
+  spaces to rebuild the conditions on.
+
+#### get\_observations
+
+```python
+def get_observations()
+```
+
+Compute the current observation vector of lift/drag coefficients.
+
+**Returns**:
+
+- `list` - Flattened list of lift coefficients followed by drag
+  coefficients, one entry per cylinder.
+
+#### evaluate\_objective
+
+```python
+def evaluate_objective(q=None)
+```
+
+Compute the objective: the total drag over all cylinders.
+
+**Arguments**:
+
+- `q` _fd.Function, optional_ - Flow state to evaluate; defaults to
+  the current state.
+  
+
+**Returns**:
+
+- `float` - Sum of the drag coefficients of all cylinders.
+
+#### render
+
+```python
+def render(mode="human", clim=None, levels=None, cmap="RdBu", **kwargs)
+```
+
+Render the current vorticity field with the cylinder circles overlaid.
+
+**Arguments**:
+
+- `mode` _str, optional_ - Rendering mode; only &quot;human&quot; plotting is
+  implemented.
+- `clim` _tuple, optional_ - (min, max) color limits for the
+  vorticity plot. Default (-2, 2).
+- `levels` _array, optional_ - Contour levels; defaults to 10
+  levels spanning ``clim``.
+- `cmap` _str, optional_ - Matplotlib colormap name. Default &quot;RdBu&quot;.
+- `**kwargs` - Additional keyword arguments passed to
+  ``tricontourf``.
+  
+
+**Raises**:
+
+- `AttributeError` - As written this method reads the vorticity and
+  cylinder geometry from a ``self.flow`` attribute, which
+  ``FlowConfig`` does not define, so rendering a bare
+  ``Pinball`` instance will fail.
 

--- a/docs/docs/api/firedrake/envs/step/flow.md
+++ b/docs/docs/api/firedrake/envs/step/flow.md
@@ -33,6 +33,176 @@ Arbitrary... should tune this
 
 Time constant for controller damping (0.01*instability frequency)
 
+#### \_\_init\_\_
+
+```python
+def __init__(**kwargs)
+```
+
+Initialize the step flow, including the random forcing parameters.
+
+**Arguments**:
+
+- `**kwargs` - Forwarded to ``FlowConfig``, after removing:
+  - noise_amplitude (float): Amplitude of the white-noise
+  forcing. Default 1.0.
+  - noise_time_constant (float): Time constant of the
+  low-pass filter on the noise. Defaults to
+  ``10 * TAU``.
+  - noise_seed (int, optional): Seed for the PCG64 random
+  generator; None gives nondeterministic noise.
+
+#### num\_inputs
+
+```python
+@property
+def num_inputs() -> int
+```
+
+Number of control inputs: one (blowing/suction on the step edge).
+
+#### nu
+
+```python
+@property
+def nu()
+```
+
+Kinematic viscosity ``0.5 / Re`` (half the base-class value).
+
+**Returns**:
+
+- `fd.Constant` - The kinematic viscosity used by this flow.
+
+#### body\_force
+
+```python
+@property
+def body_force()
+```
+
+Localized body force driven by the low-pass-filtered noise state.
+
+**Returns**:
+
+- `fd.Function` - A vector function on the velocity space with a
+  Gaussian bump centered at (-1.0, 0.25), scaled by the current
+  ``noise_state``.
+
+#### configure\_observations
+
+```python
+def configure_observations(obs_type=None,
+                           probe_obs_types=`{}`) -> ObservationFunction
+```
+
+Select the observation function for the step.
+
+**Arguments**:
+
+- `obs_type` _str, optional_ - Observation type. Defaults to
+  &quot;stress_sensor&quot; (shear stress on the downstream wall).
+  Probe-based types passed in ``probe_obs_types`` are also
+  supported.
+- `probe_obs_types` _dict, optional_ - Probe-based observation
+  functions provided by ``FlowConfig``.
+  
+
+**Returns**:
+
+- `ObservationFunction` - The selected observation function.
+  
+
+**Raises**:
+
+- `ValueError` - If ``obs_type`` is not a supported type.
+
+#### init\_bcs
+
+```python
+def init_bcs(function_spaces=None)
+```
+
+Construct and apply the step boundary conditions.
+
+Creates a parabolic inflow profile, no-slip walls, and outflow
+conditions, plus the time-varying actuation boundary condition on
+the step edge (``ScaledDirichletBC``), then applies the current
+control state.
+
+**Arguments**:
+
+- `function_spaces` _optional_ - Pair of (velocity, pressure)
+  spaces to build conditions on; defaults to the subspaces
+  of the mixed space.
+
+#### advance\_time
+
+```python
+def advance_time(dt, control=None)
+```
+
+Advance the flow time by ``dt``, updating the stochastic forcing first.
+
+Draws a white-noise sample (on rank zero of the MPI communicator,
+then broadcast to all ranks), low-pass-filters the noise state
+with the actuator-style filter (time constant ``noise_tau``), and
+then calls the parent ``advance_time`` to update the flow state
+and actuator.
+
+**Arguments**:
+
+- `dt` _float_ - Time step size.
+- `control` _ArrayLike, optional_ - Control input(s) passed through
+  to the parent solver.
+  
+
+**Returns**:
+
+- `list` - The updated actuator (control) state, as returned by
+  ``FlowConfig.advance_time``.
+
+#### linearize\_bcs
+
+```python
+def linearize_bcs(function_spaces=None)
+```
+
+Set boundary conditions to zero-amplitude for linearized problems.
+
+Resets the controls to zero (which scales the actuation BC to
+zero), reinitializes the boundary conditions, and sets the inflow
+profile to zero.
+
+**Arguments**:
+
+- `function_spaces` _optional_ - Pair of (velocity, pressure)
+  spaces to rebuild the conditions on.
+
+#### collect\_bcu
+
+```python
+def collect_bcu()
+```
+
+List of velocity boundary conditions (inflow, walls, actuation).
+
+**Returns**:
+
+- `list` - All velocity ``DirichletBC`` objects for this flow.
+
+#### collect\_bcp
+
+```python
+def collect_bcp()
+```
+
+List of pressure boundary conditions.
+
+**Returns**:
+
+- `list` - Pressure ``DirichletBC`` objects (zero pressure at the outlet).
+
 #### wall\_stress\_sensor
 
 ```python
@@ -40,4 +210,53 @@ def wall_stress_sensor(q=None)
 ```
 
 Integral of wall-normal shear stress (see Barbagallo et al, 2009)
+
+#### evaluate\_objective
+
+```python
+def evaluate_objective(q=None, qB=None)
+```
+
+Compute the fluctuation kinetic energy relative to a base flow.
+
+**Arguments**:
+
+- `q` _fd.Function, optional_ - Flow state to evaluate; defaults to
+  the current state.
+- `qB` _fd.Function, optional_ - Base flow to subtract; defaults to
+  the stored base flow ``self.qB``.
+  
+
+**Returns**:
+
+- `float` - ``0.5 * ||u - uB||_L2^2`` of the velocity fields.
+
+#### render
+
+```python
+def render(mode="human",
+           axes=None,
+           clim=None,
+           levels=None,
+           cmap="RdBu",
+           xlim=None,
+           **kwargs)
+```
+
+Render the current vorticity field with matplotlib.
+
+**Arguments**:
+
+- `mode` _str, optional_ - Rendering mode; only &quot;human&quot; plotting is
+  implemented.
+- `axes` _optional_ - Matplotlib axes to draw on; a new figure of
+  size (12, 2) is created if None.
+- `clim` _tuple, optional_ - (min, max) color limits for the
+  vorticity plot. Default (-5, 5).
+- `levels` _array, optional_ - Contour levels; defaults to 20
+  levels spanning ``clim``.
+- `cmap` _str, optional_ - Matplotlib colormap name. Default &quot;RdBu&quot;.
+- `xlim` _list, optional_ - Horizontal axis limits. Default [-2, 10].
+- `**kwargs` - Additional keyword arguments passed to
+  ``tricontourf``.
 

--- a/docs/docs/api/firedrake/flow.md
+++ b/docs/docs/api/firedrake/flow.md
@@ -3,11 +3,115 @@ sidebar_label: flow
 title: hydrogym.firedrake.flow
 ---
 
+## ScaledDirichletBC Objects
+
+```python
+class ScaledDirichletBC(fd.DirichletBC)
+```
+
+Dirichlet boundary condition whose value can be rescaled in place.
+
+Wraps a Firedrake ``DirichletBC`` and multiplies the prescribed value
+``g`` by an internal ``fd.Constant`` scale factor, so that the amplitude
+of a boundary condition (e.g. actuation blowing/suction) can be changed
+during a simulation without rebuilding the boundary condition. Call
+``set_scale`` to change the factor.
+
+**Attributes**:
+
+- `unscaled_function_arg` - The original (unscaled) value ``g`` passed in.
+
+#### \_\_init\_\_
+
+```python
+def __init__(V, g, sub_domain, method=None)
+```
+
+Construct the scaled boundary condition.
+
+**Arguments**:
+
+- `V` _fd.FunctionSpace_ - Function space the condition applies to.
+- `g` - Value to prescribe; may be a UFL expression. The stored
+  condition is ``self._scale * g``.
+- `sub_domain` - Mesh marker(s) of the boundary facets.
+- `method` - Boundary condition method, for compatibility with older
+  Firedrake versions whose ``DirichletBC`` still accepts it.
+  Newer versions ignore it.
+  
+
+**Notes**:
+
+  Firedrake&#x27;s constructor signature changed across versions, so
+  several calling conventions are tried in turn.
+
+#### set\_scale
+
+```python
+def set_scale(c)
+```
+
+Set the multiplicative factor applied to the prescribed value.
+
+**Arguments**:
+
+- `c` - New scale factor; assigned to the internal ``fd.Constant``
+  so it can be updated without rebuilding the condition.
+
+## ObservationFunction Objects
+
+```python
+class ObservationFunction(NamedTuple)
+```
+
+Observation function paired with the number of values it produces.
+
+**Attributes**:
+
+- `func` _Callable_ - Function mapping a flow state to a numpy array.
+- `num_outputs` _int_ - Size of the array returned by ``func``.
+
+#### \_\_call\_\_
+
+```python
+def __call__(q: fd.Function) -> np.ndarray
+```
+
+Evaluate the wrapped observation function on a flow state.
+
+**Arguments**:
+
+- `q` _fd.Function_ - Flow state to observe.
+  
+
+**Returns**:
+
+- `np.ndarray` - Observation values computed by ``func``.
+
 ## FlowConfig Objects
 
 ```python
 class FlowConfig(PDEBase)
 ```
+
+Base class for incompressible Navier-Stokes flow configurations.
+
+A ``FlowConfig`` owns the mesh, the mixed velocity/pressure function
+space, the current state ``q``, the boundary conditions, and the
+observation function used for RL feedback. Concrete environments
+(cavity, cylinder, pinball, step) subclass this and provide at minimum
+``init_bcs``/``collect_bcu``/``collect_bcp``, ``linearize_bcs``, and
+``configure_observations``.
+
+Checkpoints can be resolved automatically: if no ``restart`` is given,
+an environment name is inferred from the class name, Reynolds number,
+and mesh, and a matching checkpoint is fetched from the Hugging Face
+Hub via the data manager (falling back to a zero initial condition if
+none is found). If the resolved environment has more than one
+candidate checkpoint file, the pick is deterministic (sorted by
+filename, last wins) but not guaranteed physically appropriate for
+every use case -- pass an explicit checkpoint file path in ``restart``
+if a specific one is required.
 
 #### DEFAULT\_VELOCITY\_ORDER
 
@@ -16,6 +120,178 @@ Taylor-Hood elements
 #### FUNCTIONS
 
 tuple of functions necessary for the flow
+
+#### \_\_init\_\_
+
+```python
+def __init__(velocity_order=None, **config)
+```
+
+Initialize the flow configuration.
+
+**Arguments**:
+
+- `velocity_order` _int, optional_ - Polynomial order of the
+  Taylor-Hood velocity elements. Defaults to
+  ``DEFAULT_VELOCITY_ORDER``.
+- `**config` - Remaining configuration, consumed as keyword
+  arguments:
+  - Re (float): Reynolds number. Defaults to
+  ``DEFAULT_REYNOLDS``.
+  - probes (list): (x, y) probe locations used by the probe
+  observation types; validated against the mesh on
+  initialization unless ``validate_probes`` is False.
+  - validate_probes (bool): Whether to check that ``probes``
+  lie inside the mesh. Default True.
+  - observation_type (str): Key selecting the observation
+  function, forwarded to ``configure_observations``.
+  - restart: Checkpoint to load: an explicit path, a
+  Hugging Face Hub environment name, or a list of either.
+  If None, a checkpoint is auto-inferred from the class
+  name, Re, and mesh (and may be None if none is found).
+  - mesh (str): Mesh name (e.g. &quot;medium&quot;). Defaults to
+  ``DEFAULT_MESH``.
+  - cache_dir, local_dir (str, optional): Custom cache and
+  local fallback directories for checkpoint downloads.
+  - use_HF_data_manager (bool): Whether to resolve
+  checkpoints via the Hugging Face Hub. Default True.
+  - hf_token (str, optional): Access token for private/gated
+  Hub repos.
+  - hf_revision (str, optional): Hub revision to pin
+  downloads to.
+
+#### load\_mesh
+
+```python
+def load_mesh(name: str) -> ufl.Mesh
+```
+
+Load a Gmsh mesh by name from ``MESH_DIR``.
+
+**Arguments**:
+
+- `name` _str_ - Mesh name, e.g. &quot;medium&quot;; reads
+  ``{MESH_DIR}/`{name}`.msh``.
+  
+
+**Returns**:
+
+- `ufl.Mesh` - The loaded Firedrake mesh.
+
+#### save\_checkpoint
+
+```python
+def save_checkpoint(filename: str, write_mesh=True, idx=None)
+```
+
+Save the current state and actuator states to a Firedrake checkpoint.
+
+Every function named in ``FUNCTIONS`` is written, along with the
+state of each actuator as a file-level attribute &quot;act_state&quot;.
+
+**Arguments**:
+
+- `filename` _str_ - Path of the checkpoint file to write.
+- `write_mesh` _bool, optional_ - Whether to also save the mesh.
+  Default True.
+- `idx` _int, optional_ - Time index to attach to the saved
+  functions, if any.
+
+#### load\_checkpoint
+
+```python
+def load_checkpoint(filename: str, idx=None, read_mesh=True)
+```
+
+Load the flow state (and actuator states) from a checkpoint.
+
+Each function named in ``FUNCTIONS`` is read back onto the current
+function space; if the checkpoint was written on a different
+element, the field is projected onto the current space instead of
+being assigned directly. Missing functions default to zero with a
+warning. If a stored &quot;act_state&quot; attribute is present, it is used
+to restore each actuator&#x27;s state.
+
+**Arguments**:
+
+- `filename` _str_ - Path of the checkpoint file to read.
+- `idx` _int, optional_ - Time index of the saved functions to load.
+- `read_mesh` _bool, optional_ - Whether to load the mesh from the
+  file and reinitialize state. Default True; if False, the
+  current mesh must already be initialized.
+
+#### configure\_observations
+
+```python
+def configure_observations(obs_type=None,
+                           probe_obs_types=`{}`) -> ObservationFunction
+```
+
+Select the observation function for this flow.
+
+Subclasses should build a mapping of available observation types
+(including the probe-based ones passed in ``probe_obs_types``) and
+return the one named by ``obs_type``, raising ``ValueError`` for an
+unknown type.
+
+**Arguments**:
+
+- `obs_type` _str, optional_ - Name of the desired observation type.
+  Defaults to a subclass-specific choice.
+- `probe_obs_types` _dict, optional_ - Mapping of probe-based
+  observation type names to ``ObservationFunction`` objects,
+  as constructed by ``FlowConfig.__init__``.
+  
+
+**Returns**:
+
+- ``2 - The selected observation function.
+  
+
+**Raises**:
+
+- ``3 - In the base class; subclasses must
+  override this.
+
+#### get\_observations
+
+```python
+def get_observations() -> np.ndarray
+```
+
+Compute the current observation vector.
+
+**Returns**:
+
+- `np.ndarray` - Output of the configured observation function
+  evaluated on the current state.
+
+#### num\_outputs
+
+```python
+@property
+def num_outputs() -> int
+```
+
+Number of values in the observation vector.
+
+This may be lift/drag, a stress &quot;sensor&quot;, or a set of probe
+locations, depending on the configured observation type.
+
+#### initialize\_state
+
+```python
+def initialize_state()
+```
+
+Create the function spaces and state functions on the current mesh.
+
+Sets up the Taylor-Hood mixed space (continuous vector-valued
+velocity of order ``velocity_order`` and continuous piecewise-linear
+pressure), allocates one ``fd.Function`` per name in ``FUNCTIONS``,
+breaks out the velocity and pressure subfunctions, allocates the
+internal vorticity field, and validates any configured probe
+locations.
 
 #### set\_state
 
@@ -62,6 +338,27 @@ the two are not necessarily called together (e.g.
 for linearization or deriving the control vector)
 
 TODO: Allow for different kinds of actuators
+
+#### nu
+
+```python
+@property
+def nu()
+```
+
+Kinematic viscosity ``1 / Re`` as a Firedrake Constant.
+
+#### split\_solution
+
+```python
+def split_solution()
+```
+
+Break the mixed state out into velocity and pressure fields.
+
+Assigns ``self.u`` and ``self.p`` to the subfunctions of ``self.q``
+and renames them to &quot;u&quot; and &quot;p&quot;, so that fields saved under those
+names stay consistent after loading or reinitializing state.
 
 #### vorticity
 
@@ -168,6 +465,21 @@ def max_cfl(dt) -> float
 
 Estimate of maximum CFL number
 
+#### body\_force
+
+```python
+@property
+def body_force()
+```
+
+Volumetric body force term (zero by default).
+
+**Returns**:
+
+- `fd.Function` - A vector function on the velocity space, assigned
+  to zero. Subclasses may override this to return a nontrivial
+  forcing field.
+
 #### linearize\_bcs
 
 ```python
@@ -230,4 +542,48 @@ def vorticity_probe(probes, q: fd.Function = None) -> list[float]
 ```
 
 Probe vorticity in the wake.
+
+#### linearize
+
+```python
+def linearize(qB=None,
+              adjoint=False,
+              sigma=0.0,
+              inverse=False,
+              solver_parameters=None)
+```
+
+Return a linear operator for the Navier-Stokes equations about a base flow.
+
+By default returns the Jacobian operator ``dF/dq`` evaluated at the
+base state ``qB``. With ``inverse=True``, returns an operator that
+solves the mass-matrix pencil ``(J - sigma * M) @ v1 = M @ v0``,
+shifted by the (possibly complex) ``sigma``; complex shifts are
+handled as a real block system with twice the degrees of freedom.
+
+**Arguments**:
+
+- ``0 _fd.Function, optional_ - Base state to linearize about.
+  Defaults to the current state.
+- ``1 _bool, optional_ - Whether to return the transpose
+  (adjoint) of the operator. Default False.
+- ``2 _complex, optional_ - Spectral shift. Default 0.0; must be
+  zero unless ``inverse=True``.
+- ``5 _bool, optional_ - Whether to return a shift-inverse
+  (solve) operator instead of the Jacobian itself. Default
+  False.
+- ``6 _dict, optional_ - PETSc solver parameters for
+  the inverse operators.
+  
+
+**Returns**:
+
+  DirectOperator or InverseOperator: The requested linear
+  operator (transposed if ``adjoint=True``).
+  
+
+**Raises**:
+
+- ``9 - If a nonzero ``sigma`` is given with
+  ``inverse=False``.
 

--- a/docs/docs/api/firedrake/solvers/base.md
+++ b/docs/docs/api/firedrake/solvers/base.md
@@ -9,6 +9,36 @@ title: hydrogym.firedrake.solvers.base
 class NewtonSolver()
 ```
 
+Newton solver for the steady-state Navier-Stokes equations.
+
+Assembles the nonlinear steady residual of ``flow.steady_form`` (with
+optional SUPG/GLS-type stabilization) and solves the resulting
+nonlinear variational problem with Firedrake&#x27;s Newton solver.
+
+#### \_\_init\_\_
+
+```python
+def __init__(flow: FlowConfig,
+             stabilization: str = "none",
+             solver_parameters: dict = `{}`)
+```
+
+Configure the steady solver.
+
+**Arguments**:
+
+- `flow` _FlowConfig_ - Flow configuration defining the mesh,
+  function spaces, and boundary conditions.
+- `stabilization` _str, optional_ - Stabilization method, one of
+  the keys of ``ns_stabilization``. Default &quot;none&quot;.
+- `solver_parameters` _dict, optional_ - Parameters passed through
+  to ``fd.NonlinearVariationalSolver``.
+  
+
+**Raises**:
+
+- `ValueError` - If ``stabilization`` is not a recognized type.
+
 #### solve
 
 ```python
@@ -16,4 +46,99 @@ def solve(q: fd.Function = None)
 ```
 
 Solve the steady-state problem from initial guess `q`
+
+#### steady\_form
+
+```python
+def steady_form(q: fd.Function, q_test=None)
+```
+
+Assemble the nonlinear steady-state Navier-Stokes variational form.
+
+Builds ``F(u, p; v, s)`` with the sign convention used for
+steady solves (advection and stress terms positive), plus any
+stabilization terms. This differs from ``FlowConfig.residual``,
+whose signs are written for the transient problem.
+
+**Arguments**:
+
+- `q` _fd.Function_ - Mixed trial state (u, p).
+- `q_test` _optional_ - Pair of test functions (v, s); defaults to
+  the test functions of the flow&#x27;s mixed space.
+  
+
+**Returns**:
+
+- `ufl.Form` - The nonlinear residual form.
+
+## NavierStokesTransientSolver Objects
+
+```python
+class NavierStokesTransientSolver(TransientSolver)
+```
+
+Base class for transient Navier-Stokes solvers.
+
+Extends ``TransientSolver`` with a hook-based reset: subclasses
+allocate their fields and variational forms in
+``initialize_functions`` and ``initialize_operators``, both of which
+are invoked on construction and on every ``reset``.
+
+#### \_\_init\_\_
+
+```python
+def __init__(flow: FlowConfig, dt: float = None, debug: bool = False)
+```
+
+Initialize the transient solver.
+
+**Arguments**:
+
+- `flow` _FlowConfig_ - Flow configuration to advance in time.
+- `dt` _float, optional_ - Time step. Defaults to ``TransientSolver``&#x27;s
+  handling (typically the flow&#x27;s ``DEFAULT_DT``).
+- `debug` _bool, optional_ - Whether to enable debug output.
+  Default False.
+  
+
+**Notes**:
+
+  This class previously accepted ``eta``/``max_noise_iter``/
+  ``noise_cutoff`` for a random white-noise body forcing, but the
+  forcing was removed upstream (a067781, 2024-03) and those
+  kwargs were silently ignored ever since; they were removed in
+  this repo&#x27;s audit Task 2.3.
+
+#### reset
+
+```python
+def reset()
+```
+
+Reset the solver to its initial condition and rebuild state.
+
+Calls the parent reset, then re-runs ``initialize_functions`` and
+``initialize_operators``.
+
+#### initialize\_functions
+
+```python
+def initialize_functions()
+```
+
+Allocate solver-specific state fields.
+
+No-op in the base class; subclasses should override this to create
+the functions they need.
+
+#### initialize\_operators
+
+```python
+def initialize_operators()
+```
+
+Allocate solver-specific variational forms and operators.
+
+No-op in the base class; subclasses should override this to set up
+their forms/operators.
 

--- a/docs/docs/api/firedrake/solvers/bdf_ext.md
+++ b/docs/docs/api/firedrake/solvers/bdf_ext.md
@@ -1,0 +1,168 @@
+---
+sidebar_label: bdf_ext
+title: hydrogym.firedrake.solvers.bdf_ext
+---
+
+## SemiImplicitBDF Objects
+
+```python
+class SemiImplicitBDF(NavierStokesTransientSolver)
+```
+
+Semi-implicit BDF transient solver for the incompressible Navier-Stokes equations.
+
+Uses a backward-differentiation formula of order ``k`` for the time
+derivative (treated implicitly, together with the viscous and pressure
+terms) and a k-th-order extrapolation of the velocity for the convective
+term, which is thereby treated explicitly. The result is a sequence of
+linear variational problems, one per BDF order, solved each timestep with
+Firedrake&#x27;s ``LinearVariationalSolver``.
+
+For ``k &gt; 1`` the first ``k - 1`` timesteps are taken with lower-order
+startup solvers (order 1 .. k-1, each with a matching extrapolation),
+since the full-order scheme needs ``k`` previous solutions.
+
+**Attributes**:
+
+- ``0 - Order of the BDF/extrapolation scheme (1, 2, or 3).
+- ``1 - Relative tolerance for the Krylov solver.
+- ``2 - User-supplied PETSc solver parameters,
+  overriding the built-in defaults (see ``_make_petsc_solver``).
+- ``5 - Name of the stabilization scheme (a key of
+  :data:``6);
+  ``&quot;default&quot;`` resolves to ``flow.DEFAULT_STABILIZATION``.
+- ``1 - List of the ``k`` most recent velocity solutions (oldest
+  first) used to build the BDF and extrapolation combinations.
+
+#### \_\_init\_\_
+
+```python
+def __init__(flow: FlowConfig,
+             dt: float = None,
+             order: int = 3,
+             stabilization: str = "default",
+             rtol=1e-6,
+             solver_parameters: dict = None,
+             **kwargs)
+```
+
+Initialize the solver and build the BDF/startup operators.
+
+**Arguments**:
+
+- `flow` - Flow configuration (mesh, mixed space, BCs, forcing).
+- `dt` - Timestep size. Optional; defaults to the flow&#x27;s
+  ``DEFAULT_DT`` if not given (see
+  ``NavierStokesTransientSolver``/``TransientSolver``, whose
+  contract this class previously broke by requiring ``dt``
+  positionally).
+- `dt`0 - Order of the BDF/extrapolation scheme (1-3).
+- `dt`1 - Stabilization type; ``&quot;default&quot;`` resolves to the
+  flow&#x27;s ``DEFAULT_STABILIZATION``. See ``ns_stabilization`` for
+  the available keys (e.g. &quot;none&quot;, &quot;supg&quot;, &quot;gls&quot;, and their
+  &quot;linearized_&quot; variants).
+- `dt`8 - Relative tolerance for the Krylov (KSP) solver.
+- `dt`9 - Optional PETSc solver parameters replacing the
+  built-in defaults chosen in ``_make_petsc_solver``.
+- ``2 - Forwarded to
+  :class:``3.
+  
+
+**Raises**:
+
+- ``4 - If ``stabilization`` is not a recognized type.
+
+#### initialize\_functions
+
+```python
+def initialize_functions()
+```
+
+Allocate trial/test functions and the BDF history of previous solutions.
+
+Sets ``self.q_trial``/``self.q_test`` (velocity-pressure pairs on the
+mixed space), aliases the body force ``self.f`` from the flow
+configuration, and creates ``k`` copies of the current velocity in
+``self.u_prev`` so the first (startup) steps have valid history.
+
+#### initialize\_operators
+
+```python
+def initialize_operators()
+```
+
+Build the main order-``k`` solver and the lower-order startup solvers.
+
+Initializes the flow&#x27;s boundary conditions first, then constructs the
+full-order BDF solver and, if ``k &gt; 1``, one solver per order
+``1 .. k-1`` for the startup timesteps (``self.startup_solvers``).
+
+#### step
+
+```python
+def step(iter, control=None)
+```
+
+Advance the flow by one timestep.
+
+The flow&#x27;s time is advanced (which also applies any actuation
+scaling), the appropriate linear problem is solved — the full-order
+BDF solver once ``iter`` exceeds ``k - 1``, otherwise the matching
+lower-order startup solver — and the velocity history is shifted so
+the newest solution enters ``u_prev[0]``.
+
+**Arguments**:
+
+- `iter` - Timestep index within the solve (0-based); the first
+  ``k - 1`` iterations use the startup solvers.
+- `control` - Optional actuation value(s) forwarded to
+  ``flow.advance_time`` to scale the actuation BCs.
+  
+
+**Returns**:
+
+- ``2 - The updated flow configuration.
+
+## LinearizedBDF Objects
+
+```python
+class LinearizedBDF(SemiImplicitBDF)
+```
+
+Semi-implicit BDF solver for the Navier-Stokes equations linearized about a base flow.
+
+Instead of the full convective term, solves the linearized form
+
+``du/dt + uB . grad(u) + u . grad(uB) - div(sigma(u,p)) = f``
+
+around the base flow ``qB`` supplied at construction, with the flow&#x27;s
+boundary conditions linearized (``flow.linearize_bcs()``) and the
+base-flow velocity ``uB`` acting as the &quot;wind&quot; in the stabilization
+terms. Intended for adjoint/transient-growth-type analyses about a known
+(typically steady) state.
+
+**Attributes**:
+
+- `qB` - Base flow (mixed velocity-pressure ``fd.Function``) to
+  linearize about.
+
+#### \_\_init\_\_
+
+```python
+def __init__(*args, qB: fd.Function, **kwargs)
+```
+
+Initialize the linearized solver.
+
+**Arguments**:
+
+- `*args` - Positional arguments forwarded to
+  :class:`SemiImplicitBDF` (``flow``, ``dt``, ...).
+- `qB` - Base flow (mixed velocity-pressure function) to linearize
+  the equations about.
+- `**kwargs` - Keyword arguments forwarded to :class:`SemiImplicitBDF`.
+  ``stabilization`` defaults to ``&quot;none&quot;`` (resolved to
+  ``&quot;linearized_none&quot;``) rather than the unlinearized default;
+  a plain name (e.g. ``&quot;supg&quot;``) is automatically prefixed with
+  ``&quot;linearized_&quot;``.
+

--- a/docs/docs/api/firedrake/solvers/integrate.md
+++ b/docs/docs/api/firedrake/solvers/integrate.md
@@ -1,0 +1,24 @@
+---
+sidebar_label: integrate
+title: hydrogym.firedrake.solvers.integrate
+---
+
+#### integrate
+
+```python
+def integrate(flow,
+              t_span,
+              dt,
+              method="BDF",
+              callbacks=[],
+              controller=None,
+              collect_rewards=False,
+              **options)
+```
+
+Integrate the flow forward in time with the chosen transient method.
+
+All transient methods share `core.TransientSolver.solve`, which supports
+optional reward collection: pass `collect_rewards=True` to get back a
+`(flow, rewards)` tuple instead of just the final flow state.
+

--- a/docs/docs/api/firedrake/solvers/stabilization.md
+++ b/docs/docs/api/firedrake/solvers/stabilization.md
@@ -1,0 +1,319 @@
+---
+sidebar_label: stabilization
+title: hydrogym.firedrake.solvers.stabilization
+---
+
+## NavierStokesStabilization Objects
+
+```python
+@dataclasses.dataclass
+class NavierStokesStabilization(metaclass=abc.ABCMeta)
+```
+
+Base class (and &quot;no stabilization&quot; implementation) for Navier-Stokes stabilization schemes.
+
+Bundles everything the residual-based stabilization terms need from the
+calling solver; subclasses build the actual UFL stabilization forms in
+:meth:`stabilize`. This base class implements the identity map, i.e. the
+unstabilized Galerkin formulation (the ``&quot;none&quot;``/``&quot;linearized_none&quot;``
+options in ``ns_stabilization``).
+
+**Attributes**:
+
+- `flow` - Flow configuration (mesh, viscosity, stress/strain operators).
+- `q_trial` - ``(u, p)`` pair of trial functions on the mixed space.
+- ``1 - ``(v, s)`` pair of test functions on the mixed space.
+- ``4 - Velocity field used as the convective wind (the extrapolated
+  velocity for the nonlinear solvers, or the base flow for the
+  linearized ones).
+- ``5 - Timestep (float or ``fd.Constant``); enters the stabilization
+  parameter ``tau_M`` when given.
+- ``0 - UFL expression for the time derivative estimate (the BDF term),
+  included in the strong-form residual when given.
+- ``1 - Body forcing, subtracted from the strong-form residual when given.
+
+#### stabilize
+
+```python
+def stabilize(weak_form)
+```
+
+Return the weak form unchanged (no stabilization terms).
+
+**Arguments**:
+
+- `weak_form` - The unstabilized UFL weak form.
+  
+
+**Returns**:
+
+  The same weak form, unmodified.
+
+## UpwindNSStabilization Objects
+
+```python
+class UpwindNSStabilization(NavierStokesStabilization)
+```
+
+Residual-based upwind stabilization for the (unlinearized) Navier-Stokes equations.
+
+Shared machinery for SUPG and GLS: computes the strong-form momentum
+residual ``Lu`` with the given wind, the stabilization parameters
+``tau_M``/``tau_C`` from the element size, wind magnitude, viscosity and
+(optionally) timestep, and adds ``tau_M &lt;Lu, Lv&gt;`` plus a least-squares
+incompressibility (LSIC) term ``tau_C &lt;div u, div v&gt;`` to the weak form.
+Subclasses define ``Lv``, the residual operator applied to the test
+functions.
+
+Attributes (inherited from :class:``2) supply the
+trial/test functions, wind, timestep, time derivative and forcing.
+
+#### h
+
+```python
+@property
+def h()
+```
+
+Mesh cell size (UFL ``CellSize``), the length scale in ``tau_M``.
+
+#### Lu
+
+```python
+@property
+def Lu()
+```
+
+Strong-form momentum residual of the trial functions.
+
+``w . grad(u) - div(sigma(u,p))``, plus the time-derivative estimate
+``u_t`` and minus the forcing ``f`` when those are supplied.
+
+**Returns**:
+
+  UFL expression for ``Lu`` (the momentum residual).
+
+#### Lv
+
+```python
+@abc.abstractproperty
+def Lv()
+```
+
+Residual operator applied to the test functions (subclass-specific).
+
+**Returns**:
+
+  UFL expression for ``Lv``, paired with ``Lu`` in the
+  stabilization inner product.
+
+#### tau\_M
+
+```python
+@property
+def tau_M()
+```
+
+Stabilization parameter for the momentum residual.
+
+``tau_M = (4|w|^2/h^2 + 9 (4 nu / h^2)^2 [+ 4/dt^2])^(-1/2)``, i.e.
+the inverse squared &quot;elemental&quot; advective/diffusive/temporal rates.
+Based on:
+https://github.com/florianwechsung/alfi/blob/master/alfi/stabilisation.py
+
+**Returns**:
+
+  UFL expression for ``tau_M``.
+
+#### tau\_C
+
+```python
+@property
+def tau_C()
+```
+
+Stabilization parameter for the continuity residual, ``h^2 / tau_M``.
+
+**Returns**:
+
+  UFL expression for ``tau_C``.
+
+#### momentum\_stabilization
+
+```python
+@property
+def momentum_stabilization()
+```
+
+Momentum stabilization term ``tau_M &lt;Lu, Lv&gt; dx``.
+
+**Returns**:
+
+  UFL form to be added to the weak form.
+
+#### lsic\_stabilization
+
+```python
+@property
+def lsic_stabilization()
+```
+
+Least-squares incompressibility (LSIC) term ``tau_C &lt;div u, div v&gt; dx``.
+
+**Returns**:
+
+  UFL form to be added to the weak form.
+
+#### stabilize
+
+```python
+def stabilize(weak_form)
+```
+
+Add the momentum and LSIC stabilization terms to a weak form.
+
+**Arguments**:
+
+- `weak_form` - The unstabilized UFL weak form.
+  
+
+**Returns**:
+
+  The weak form with ``momentum_stabilization`` and
+  ``lsic_stabilization`` appended.
+
+## SUPG Objects
+
+```python
+class SUPG(UpwindNSStabilization)
+```
+
+Streamline-Upwind/Petrov-Galerkin stabilization.
+
+Uses only the streamline derivative ``w . grad(v)`` of the velocity test
+function as the residual operator ``Lv``, so the stabilization acts
+along the flow direction.
+
+#### Lv
+
+```python
+@property
+def Lv()
+```
+
+Streamline derivative of the velocity test function, ``w . grad(v)``.
+
+**Returns**:
+
+  UFL expression for ``Lv``.
+
+## GLS Objects
+
+```python
+class GLS(UpwindNSStabilization)
+```
+
+Galerkin least-squares stabilization.
+
+Uses the full momentum operator applied to the test functions,
+``Lv = w . grad(v) - div(sigma(v, s))``, so the least-squares term
+minimizes the complete momentum residual (not just its streamline
+component, as SUPG does).
+
+#### Lv
+
+```python
+@property
+def Lv()
+```
+
+Full momentum operator applied to the test functions.
+
+``w . grad(v) - div(sigma(v, s))``.
+
+**Returns**:
+
+  UFL expression for ``Lv``.
+
+## LinearizedNSStabilization Objects
+
+```python
+class LinearizedNSStabilization(UpwindNSStabilization)
+```
+
+Residual-based stabilization for the Navier-Stokes equations linearized about a base flow.
+
+Identical machinery to :class:`UpwindNSStabilization`, except the
+strong-form momentum residual ``Lu`` uses the linearized convective
+operator ``uB . grad(u) + u . grad(uB)``, where the base flow ``uB`` is
+supplied as the ``wind``.
+
+#### Lu
+
+```python
+@property
+def Lu()
+```
+
+Strong-form momentum residual of the linearized operator.
+
+``uB . grad(u) + u . grad(uB) - div(sigma(u,p))``, plus the
+time-derivative estimate ``u_t`` and minus the forcing ``f`` when
+those are supplied.
+
+**Returns**:
+
+  UFL expression for the linearized momentum residual ``Lu``.
+
+## LinearizedSUPG Objects
+
+```python
+class LinearizedSUPG(LinearizedNSStabilization)
+```
+
+Streamline-upwind stabilization of the base-flow-linearized equations.
+
+The SUPG residual operator about the base flow: both linearized
+convective terms applied to the test function.
+
+#### Lv
+
+```python
+@property
+def Lv()
+```
+
+Linearized streamline derivative of the test function.
+
+``uB . grad(v) + v . grad(uB)``.
+
+**Returns**:
+
+  UFL expression for ``Lv``.
+
+## LinearizedGLS Objects
+
+```python
+class LinearizedGLS(LinearizedNSStabilization)
+```
+
+Galerkin least-squares stabilization of the base-flow-linearized equations.
+
+The full linearized momentum operator applied to the test functions
+(linearized convective terms plus the viscous/pressure operator).
+
+#### Lv
+
+```python
+@property
+def Lv()
+```
+
+Full linearized momentum operator applied to the test functions.
+
+``uB . grad(v) + v . grad(uB) - div(sigma(v, s))``.
+
+**Returns**:
+
+  UFL expression for ``Lv``.
+

--- a/docs/docs/api/hf_env_mixin.md
+++ b/docs/docs/api/hf_env_mixin.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: hf_env_mixin
+title: hydrogym.hf_env_mixin
+---
+
+Shared Hugging-Face environment-config resolution logic (audit Task 3.1).
+
+Four backends (jaxfluids, jax, maia, nek) carried near-identical private
+copies of the same three methods:
+
+_setup_environment_data()      -- local ~/.cache/&lt;namespace&gt;/&lt;env&gt; lookup,
+falling back to HFDataManager
+_resolve_configuration_file()  -- None / abs path / ./relative / filename
+_find_configuration_file()     -- auto-detect config.yaml in the env dir
+
+with only the cache-namespace string differing per backend. This module
+extracts them into `HFEnvConfigMixin`, parameterized by the class-level
+`HF_CACHE_NAMESPACE` (and, for data-manager construction, `SOLVER_TYPE`).
+Backends migrate to the mixin one at a time to keep blast radius small;
+the method bodies here are copied verbatim from the JAX-Fluids backend,
+which is migrated first (Task 3.1).
+
+## ConfigError Objects
+
+```python
+class ConfigError(Exception)
+```
+
+Exception raised for configuration-related errors.
+
+## HFEnvConfigMixin Objects
+
+```python
+class HFEnvConfigMixin()
+```
+
+Environment-data download / config-file resolution shared by the
+HF-backed backends.
+
+Requires on the consuming class:
+- ``HF_CACHE_NAMESPACE``: per-backend cache directory name under
+``~/.cache`` (e.g. &quot;jaxfluidsgym&quot;, &quot;jaxgym&quot;, &quot;maiagym&quot;, &quot;nekgym&quot;).
+- ``self.environment_name``, ``self.env_data_path``, and a
+``self.data_manager`` (HFDataManager) instance before the
+resolution methods are called (i.e. ``_init_from_hf`` order:
+data_manager -&gt; environment_name -&gt; _setup_environment_data -&gt;
+_resolve_configuration_file).
+

--- a/docs/docs/api/jax/env_core.md
+++ b/docs/docs/api/jax/env_core.md
@@ -9,18 +9,24 @@ Core Jax Gym Environment Module
 This module provides the base environment class for CFD reinforcement learning
 with Hugging Face Hub integration for configuration management.
 
-## ConfigError Objects
+## EnvParams Objects
 
 ```python
-class ConfigError(Exception)
+class EnvParams(environment.EnvParams)
 ```
 
-Exception raised for configuration-related errors.
+Gymnax environment parameters extended with the environment config dictionary.
+
+**Attributes**:
+
+- `config` - Environment configuration (grid sizes, control bounds, etc.)
+  as loaded from the environment&#x27;s configuration file.
 
 ## JAXFlowEnv Objects
 
 ```python
-class JAXFlowEnv(environment.Environment[EnvState, EnvParams])
+class JAXFlowEnv(HFEnvConfigMixin, environment.Environment[EnvState,
+                                                           EnvParams])
 ```
 
 Base JAXFlowEnv with Hugging Face Hub integration for configuration management.
@@ -129,6 +135,101 @@ Update environment data from HF Hub.
 
 - `force_download` - Force re-download even if cached.
 
+#### reset\_env
+
+```python
+def reset_env(key: chex.PRNGKey,
+              params: EnvParams) -> Tuple[chex.Array, EnvState]
+```
+
+Reset the environment to its initial condition.
+
+**Arguments**:
+
+- `key` - PRNG key for stochastic resets.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, state)`` of the initial observation and state.
+  
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses define the actual reset.
+
+#### get\_obs
+
+```python
+def get_obs(state: EnvState, params: EnvParams, key=None) -> chex.Array
+```
+
+Compute the observation from the current environment state.
+
+**Arguments**:
+
+- `state` - Current environment state.
+- `params` - Environment parameters.
+- `key` - Optional PRNG key for stochastic observations.
+  
+
+**Returns**:
+
+  Observation array.
+  
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses define the observation model.
+
+#### is\_terminal
+
+```python
+def is_terminal(state: EnvState, params: EnvParams) -> jnp.ndarray
+```
+
+Whether the episode has ended.
+
+An episode terminates when the state flags ``terminal`` or the elapsed
+time reaches ``params.max_episode_steps``.
+
+**Arguments**:
+
+- `state` - Current environment state.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Boolean array indicating termination.
+
+#### step\_env
+
+```python
+def step_env(key: chex.PRNGKey, state: EnvState, action: jnp.array,
+             params: EnvParams)
+```
+
+Advance the environment by one step under the given action.
+
+**Arguments**:
+
+- `key` - PRNG key for stochastic transitions.
+- `state` - Current environment state.
+- `action` - Control (actuation) input.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, next_state, reward, done, info)``.
+  
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses define the dynamics.
+
 ## JAXFlowEnvBase Objects
 
 ```python
@@ -138,6 +239,179 @@ class JAXFlowEnvBase(environment.Environment[EnvState, EnvParams])
 Base JAXFlowEnv without Hugging Face Hub integration.
 Contains core environment interface methods required by Gymnax.
 
+#### \_\_init\_\_
+
+```python
+def __init__(env_config: Optional[dict] = None)
+```
+
+Initialize the environment with an optional configuration dictionary.
+
+**Arguments**:
+
+- `env_config` - Environment configuration options (e.g.
+  ``max_episode_steps``); defaults to an empty dict.
+
+#### default\_params
+
+```python
+def default_params() -> EnvParams
+```
+
+Return the environment&#x27;s default parameters.
+
+Sets ``self.max_episode_steps`` from ``env_config`` (default 1000) as a
+side effect.
+
+**Returns**:
+
+  Default environment parameters.
+  
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses must provide the parameters.
+
+#### name
+
+```python
+def name() -> str
+```
+
+Return the environment&#x27;s name.
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses must provide a name.
+
+#### action\_space
+
+```python
+def action_space(params: Optional[EnvParams] = None)
+```
+
+Return the (Box) action space bounded by the parameters&#x27; action limits.
+
+**Arguments**:
+
+- `params` - Environment parameters; defaults to ``self.default_params``.
+  
+
+**Returns**:
+
+  Gymnax Box space of shape ``(params.action_dim,)`` with bounds
+  ``[params.min_action, params.max_action]``.
+
+#### observation\_space
+
+```python
+def observation_space(params: EnvParams)
+```
+
+Return the (Box) observation space bounded by the parameters&#x27; observation limits.
+
+**Arguments**:
+
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Gymnax Box space of shape ``(params.obs_dim,)`` with bounds
+  ``[params.min_obs, params.max_obs]``.
+
+#### is\_terminal
+
+```python
+def is_terminal(state: EnvState, params: EnvParams) -> jnp.ndarray
+```
+
+Whether the episode has ended (state flags ``terminal`` or time limit reached).
+
+**Arguments**:
+
+- `state` - Current environment state.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Boolean array indicating termination.
+
+#### reset\_env
+
+```python
+def reset_env(key: chex.PRNGKey,
+              params: EnvParams) -> Tuple[chex.Array, EnvState]
+```
+
+Reset the environment to its initial condition.
+
+**Arguments**:
+
+- `key` - PRNG key for stochastic resets.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, state)`` of the initial observation and state.
+  
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses define the actual reset.
+
+#### get\_obs
+
+```python
+def get_obs(state: EnvState, params: EnvParams, key=None) -> chex.Array
+```
+
+Compute the observation from the current environment state.
+
+**Arguments**:
+
+- `state` - Current environment state.
+- `params` - Environment parameters.
+- `key` - Optional PRNG key for stochastic observations.
+  
+
+**Returns**:
+
+  Observation array.
+  
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses define the observation model.
+
+#### step\_env
+
+```python
+def step_env(key: chex.PRNGKey, state: EnvState, action: chex.Array,
+             params: EnvParams)
+```
+
+Advance the environment by one step under the given action.
+
+**Arguments**:
+
+- `key` - PRNG key for stochastic transitions.
+- `state` - Current environment state.
+- `action` - Control (actuation) input.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, next_state, reward, done, info)``.
+  
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses define the dynamics.
+
 ## GymnaxWrapper Objects
 
 ```python
@@ -145,6 +419,26 @@ class GymnaxWrapper(object)
 ```
 
 Base class for Gymnax wrappers.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env)
+```
+
+Wrap the given environment.
+
+**Arguments**:
+
+- `env` - The Gymnax environment (or wrapper) being wrapped.
+
+#### \_\_getattr\_\_
+
+```python
+def __getattr__(name)
+```
+
+Proxy attribute access through to the wrapped environment.
 
 ## FlattenObservationWrapper Objects
 
@@ -154,6 +448,104 @@ class FlattenObservationWrapper(GymnaxWrapper)
 
 Flatten the observations of the environment.
 
+#### \_\_init\_\_
+
+```python
+def __init__(env: environment.Environment)
+```
+
+Wrap the given environment (see :class:`GymnaxWrapper`).
+
+#### observation\_space
+
+```python
+def observation_space(params) -> spaces.Box
+```
+
+Return the wrapped environment&#x27;s observation space, flattened to 1D.
+
+**Arguments**:
+
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Gymnax Box space whose shape is the product of the underlying
+  space&#x27;s shape, with the same bounds and dtype.
+  
+
+**Raises**:
+
+- `AssertionError` - If the wrapped space is not a Box.
+
+#### reset
+
+```python
+@partial(jax.jit, static_argnums=(0, ))
+def reset(
+    key: chex.PRNGKey,
+    params: Optional[environment.EnvParams] = None
+) -> Tuple[chex.Array, environment.EnvState]
+```
+
+Reset the wrapped environment and flatten the initial observation.
+
+**Arguments**:
+
+- `key` - PRNG key for the reset.
+- `params` - Environment parameters (None uses the environment default).
+  
+
+**Returns**:
+
+  Tuple ``(obs, state)`` with the flattened observation.
+
+#### step
+
+```python
+@partial(jax.jit, static_argnums=(0, ))
+def step(
+    key: chex.PRNGKey,
+    state: environment.EnvState,
+    action: Union[int, float],
+    params: Optional[environment.EnvParams] = None
+) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]
+```
+
+Step the wrapped environment and flatten the returned observation.
+
+**Arguments**:
+
+- `key` - PRNG key for the transition.
+- `state` - Current environment state.
+- `action` - Action to apply.
+- `params` - Environment parameters (None uses the environment default).
+  
+
+**Returns**:
+
+  Tuple ``(obs, state, reward, done, info)`` with the flattened
+  observation; all other values are passed through unchanged.
+
+## LogEnvState Objects
+
+```python
+@struct.dataclass
+class LogEnvState()
+```
+
+State bookkeeping for :class:`LogWrapper`.
+
+**Attributes**:
+
+- `env_state` - The wrapped environment&#x27;s own state.
+- `episode_returns` - Return accumulated so far in the current episode.
+- `episode_lengths` - Number of steps taken so far in the current episode.
+- `returned_episode_returns` - Return of the most recently completed episode.
+- `returned_episode_lengths` - Length of the most recently completed episode.
+- `timestep` - Total number of steps taken across all episodes.
+
 ## LogWrapper Objects
 
 ```python
@@ -162,11 +554,109 @@ class LogWrapper(GymnaxWrapper)
 
 Log the episode returns and lengths.
 
-## ClipAction Objects
+#### \_\_init\_\_
 
 ```python
-class ClipAction(GymnaxWrapper)
+def __init__(env: environment.Environment)
 ```
+
+Wrap the given environment (see :class:`GymnaxWrapper`).
+
+#### reset
+
+```python
+@partial(jax.jit, static_argnums=(0, ))
+def reset(
+    key: chex.PRNGKey,
+    params: Optional[environment.EnvParams] = None
+) -> Tuple[chex.Array, environment.EnvState]
+```
+
+Reset the wrapped environment and zero the episode bookkeeping.
+
+**Arguments**:
+
+- `key` - PRNG key for the reset.
+- `params` - Environment parameters (None uses the environment default).
+  
+
+**Returns**:
+
+  Tuple ``(obs, LogEnvState)`` with all counters initialized to zero.
+
+#### step
+
+```python
+@partial(jax.jit, static_argnums=(0, ))
+def step(
+    key: chex.PRNGKey,
+    state: environment.EnvState,
+    action: Union[int, float],
+    params: Optional[environment.EnvParams] = None
+) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]
+```
+
+Step the wrapped environment, updating and exporting episode statistics.
+
+Accumulates the running episode return/length and, on episode end,
+freezes them into ``returned_episode_returns``/``returned_episode_lengths``
+before resetting the running counters. These values (plus the global
+timestep and an ``returned_episode`` done flag) are added to ``info``.
+
+**Arguments**:
+
+- `key` - PRNG key for the transition.
+- `state` - Current :class:``0.
+- ``1 - Action to apply to the wrapped environment.
+- ``2 - Environment parameters (None uses the environment default).
+  
+
+**Returns**:
+
+  Tuple ``(obs, new LogEnvState, reward, done, info)`` with the
+  logging fields added to ``info``.
+
+## NavixGymnaxWrapper Objects
+
+```python
+class NavixGymnaxWrapper()
+```
+
+Adapter exposing a Navix environment through the Gymnax-style API.
+
+Wraps a Navix environment created from ``env_name`` and translates its
+reset/step/space API into the ``(obs, state, reward, done, info)`` tuple
+convention used by the other wrappers here.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env_name)
+```
+
+Create the underlying Navix environment.
+
+**Arguments**:
+
+- `env_name` - Name of the Navix environment (passed to ``navix.make``).
+
+#### reset
+
+```python
+def reset(key, params=None)
+```
+
+Reset the Navix environment.
+
+**Arguments**:
+
+- `key` - PRNG key for the reset.
+- `params` - Unused; accepted for Gymnax API compatibility.
+  
+
+**Returns**:
+
+  Tuple ``(observation, timestep)`` from the Navix reset.
 
 #### step
 
@@ -174,5 +664,385 @@ class ClipAction(GymnaxWrapper)
 def step(key, state, action, params=None)
 ```
 
-TODO: In theory the below line should be the way to do this.
+Step the Navix environment.
+
+**Arguments**:
+
+- `key` - Unused; accepted for Gymnax API compatibility.
+- `state` - Current Navix timestep (used as the environment state).
+- `action` - Action to apply.
+- `params` - Unused; accepted for Gymnax API compatibility.
+  
+
+**Returns**:
+
+  Tuple ``(observation, timestep, reward, done, info)`` where ``info``
+  is always an empty dict.
+
+#### observation\_space
+
+```python
+def observation_space(params)
+```
+
+Return the flattened Navix observation space as a Gymnax Box.
+
+**Arguments**:
+
+- `params` - Unused; accepted for Gymnax API compatibility.
+  
+
+**Returns**:
+
+  Gymnax Box with the Navix space&#x27;s bounds, flattened shape, and dtype.
+
+#### action\_space
+
+```python
+def action_space(params)
+```
+
+Return the Navix action space as a Gymnax Discrete space.
+
+**Arguments**:
+
+- `params` - Unused; accepted for Gymnax API compatibility.
+  
+
+**Returns**:
+
+  Gymnax Discrete space with the number of Navix action categories.
+
+## ClipAction Objects
+
+```python
+class ClipAction(GymnaxWrapper)
+```
+
+Wrapper that clips actions to a fixed range before stepping the environment.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env, low=-1.0, high=1.0)
+```
+
+Wrap the environment and store the clipping bounds.
+
+**Arguments**:
+
+- `env` - The environment being wrapped.
+- `low` - Lower bound for clipping actions.
+- `high` - Upper bound for clipping actions.
+
+#### step
+
+```python
+def step(key, state, action, params=None)
+```
+
+Clip the action to ``[low, high]`` and step the wrapped environment.
+
+**Arguments**:
+
+- `key` - PRNG key for the transition.
+- `state` - Current environment state.
+- `action` - Action to clip and apply.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, state, reward, done, info)`` from the wrapped environment.
+  
+
+**Notes**:
+
+- `TODO` - In theory the clip bounds should come from the action space.
+
+## TransformObservation Objects
+
+```python
+class TransformObservation(GymnaxWrapper)
+```
+
+Wrapper that applies a function to the observation after reset and step.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env, transform_obs)
+```
+
+Wrap the environment and store the observation transform.
+
+**Arguments**:
+
+- `env` - The environment being wrapped.
+- `transform_obs` - Callable applied to every observation.
+
+#### reset
+
+```python
+def reset(key, params=None)
+```
+
+Reset the wrapped environment and transform the initial observation.
+
+**Arguments**:
+
+- `key` - PRNG key for the reset.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(transformed obs, state)``.
+
+#### step
+
+```python
+def step(key, state, action, params=None)
+```
+
+Step the wrapped environment and transform the returned observation.
+
+**Arguments**:
+
+- `key` - PRNG key for the transition.
+- `state` - Current environment state.
+- `action` - Action to apply.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(transformed obs, state, reward, done, info)``.
+
+## TransformReward Objects
+
+```python
+class TransformReward(GymnaxWrapper)
+```
+
+Wrapper that applies a function to the reward after each step.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env, transform_reward)
+```
+
+Wrap the environment and store the reward transform.
+
+**Arguments**:
+
+- `env` - The environment being wrapped.
+- `transform_reward` - Callable applied to every reward.
+
+#### step
+
+```python
+def step(key, state, action, params=None)
+```
+
+Step the wrapped environment and transform the returned reward.
+
+**Arguments**:
+
+- `key` - PRNG key for the transition.
+- `state` - Current environment state.
+- `action` - Action to apply.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, state, transformed reward, done, info)``.
+
+## VecEnv Objects
+
+```python
+class VecEnv(GymnaxWrapper)
+```
+
+Wrapper that vectorizes the wrapped environment&#x27;s reset and step over batched keys/states/actions.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env)
+```
+
+Wrap the environment and install vmapped reset/step methods.
+
+**Arguments**:
+
+- `env` - The environment being wrapped.
+
+## NormalizeVecObsEnvState Objects
+
+```python
+@struct.dataclass
+class NormalizeVecObsEnvState()
+```
+
+Running-normalization bookkeeping for :class:`NormalizeVecObservation`.
+
+**Attributes**:
+
+- `mean` - Running per-dimension mean of the observations.
+- `var` - Running per-dimension variance of the observations.
+- `count` - Running count of observations seen so far.
+- `env_state` - The wrapped environment&#x27;s own state.
+
+## NormalizeVecObservation Objects
+
+```python
+class NormalizeVecObservation(GymnaxWrapper)
+```
+
+Wrapper that normalizes vectorized observations with a running mean/variance.
+
+Statistics are updated from the batch of observations at every reset/step
+(Welford-style parallel-variant merge) and observations are returned as
+``(obs - mean) / sqrt(var + 1e-8)``.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env)
+```
+
+Wrap the given environment (see :class:`GymnaxWrapper`).
+
+#### reset
+
+```python
+def reset(key, params=None)
+```
+
+Reset the wrapped environment and initialize/update the observation statistics.
+
+**Arguments**:
+
+- `key` - PRNG key for the reset.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(normalized obs, NormalizeVecObsEnvState)``.
+
+#### step
+
+```python
+def step(key, state, action, params=None)
+```
+
+Step the wrapped environment and normalize the observation batch.
+
+The running mean/variance are first merged with the batch statistics of
+the new observations; the returned observation is the batch normalized
+with the updated statistics.
+
+**Arguments**:
+
+- `key` - PRNG key for the transition.
+- `state` - Current :class:`NormalizeVecObsEnvState`.
+- `action` - Batched actions to apply.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(normalized obs, updated NormalizeVecObsEnvState, reward,
+  done, info)``.
+
+## NormalizeVecRewEnvState Objects
+
+```python
+@struct.dataclass
+class NormalizeVecRewEnvState()
+```
+
+Running-normalization bookkeeping for :class:`NormalizeVecReward`.
+
+**Attributes**:
+
+- `mean` - Running mean of the discounted episode returns.
+- `var` - Running variance of the discounted episode returns.
+- `count` - Running count of return samples seen so far.
+- `return_val` - Current discounted episode return per environment.
+- `env_state` - The wrapped environment&#x27;s own state.
+
+## NormalizeVecReward Objects
+
+```python
+class NormalizeVecReward(GymnaxWrapper)
+```
+
+Wrapper that normalizes vectorized rewards by the running variance of the discounted returns.
+
+Rewards are accumulated per environment with discount factor ``gamma`` and
+each reward is divided by ``sqrt(var + 1e-8)`` of the running return
+statistics.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env, gamma)
+```
+
+Wrap the environment and store the discount factor.
+
+**Arguments**:
+
+- `env` - The environment being wrapped.
+- `gamma` - Discount factor used to accumulate episode returns.
+
+#### reset
+
+```python
+def reset(key, params=None)
+```
+
+Reset the wrapped environment and zero the return statistics.
+
+**Arguments**:
+
+- `key` - PRNG key for the reset.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, NormalizeVecRewEnvState)`` with mean 0, variance 1,
+  and zeroed per-environment returns.
+
+#### step
+
+```python
+def step(key, state, action, params=None)
+```
+
+Step the wrapped environment and scale the reward by the running return std.
+
+The discounted episode return is updated per environment
+(``return_val * gamma * (1 - done) + reward``) and merged into the
+running mean/variance statistics; the reward is then divided by
+``sqrt(var + 1e-8)`` before being returned.
+
+**Arguments**:
+
+- `key` - PRNG key for the transition.
+- `state` - Current :class:`NormalizeVecRewEnvState`.
+- `action` - Batched actions to apply.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, updated NormalizeVecRewEnvState, scaled reward, done,
+  info)``.
 

--- a/docs/docs/api/jax/envs/channel.md
+++ b/docs/docs/api/jax/envs/channel.md
@@ -16,15 +16,499 @@ Extends base EnvParams with channel-specific settings.
 
 DNS substeps per RL step
 
+## ChannelEnvState Objects
+
+```python
+@struct.dataclass
+class ChannelEnvState(environment.EnvState)
+```
+
+Channel-flow environment state (physical-space velocity fields).
+
+**Attributes**:
+
+- `time` - Simulation time (in DNS steps) elapsed in the episode.
+- `U` - Streamwise velocity field, shape (Nx, Ny, Nz).
+- `V` - Wall-normal velocity field, shape (Nx, Ny, Nz).
+- `W` - Spanwise velocity field, shape (Nx, Ny, Nz).
+- `dt` - Current DNS timestep.
+- `terminal` - Whether the episode has terminated.
+
 ## SpectralState Objects
 
 ```python
 class SpectralState(NamedTuple)
 ```
 
+Three-component spectral (FFT&#x27;d) velocity state.
+
+**Attributes**:
+
+- `u_hat` - x-component spectrum, shape (Nx, Ny, Nz), complex.
+- `v_hat` - y-component spectrum.
+- `w_hat` - z-component spectrum.
+
 #### u\_hat
 
 (Nx,Ny,Nz), complex
+
+#### make\_obs\_grid\_indices
+
+```python
+def make_obs_grid_indices(Nx: int, Ny: int, n: int)
+```
+
+Build the (x, y) index grid used to subsample the observation plane.
+
+**Arguments**:
+
+- `Nx` - Number of grid points in x.
+- `Ny` - Number of grid points in y.
+- `n` - Number of subsample points along each axis.
+  
+
+**Returns**:
+
+  Tuple ``(Xi, Yi)`` of index arrays of shape (n, n) spanning the full
+  x/y ranges, suitable for advanced indexing of a slice of the state.
+
+#### get\_obs\_spectral\_channel
+
+```python
+def get_obs_spectral_channel(state: ChannelEnvState, params: ChannelEnvParams,
+                             Xi: jnp.ndarray, Yi: jnp.ndarray) -> chex.Array
+```
+
+Extract the channel-flow observation vector from the current state.
+
+Samples the streamwise (U) and spanwise (W) velocity at the subsampled
+grid points on the wall-parallel plane ``z = params.k_det``.
+
+**Arguments**:
+
+- `state` - Current channel environment state.
+- `params` - Channel environment parameters.
+- `Xi` - Observation x-index grid (from :func:`make_obs_grid_indices`).
+- `Yi` - Observation y-index grid.
+  
+
+**Returns**:
+
+  1D array of the sampled U and W values stacked and flattened.
+
+#### wss\_compute
+
+```python
+def wss_compute(k, U, nu=1.9e-3, z=None)
+```
+
+Compute the domain-mean wall shear stress from a finite-difference gradient.
+
+Approximates the wall-normal velocity gradient at the wall by a one-sided
+difference between wall-parallel slices ``k`` and ``0``, using the physical
+z-coordinates in ``z``.
+
+**Arguments**:
+
+- `k` - Index of the near-wall slice used for the finite difference.
+- `U` - Streamwise velocity field, shape (Nx, Ny, Nz).
+- `nu` - Kinematic viscosity used to convert the gradient to stress.
+- `z` - Physical z-coordinates of the grid points (1D array).
+  
+
+**Returns**:
+
+  Mean wall shear stress over the (Nx, Ny) plane.
+
+## PseudoSpectralNavierStokes3D Objects
+
+```python
+class PseudoSpectralNavierStokes3D(SplitEquation)
+```
+
+Pseudo-spectral 3D Navier-Stokes equation for a channel flow.
+
+Horizontal (x, y) directions are treated spectrally with FFTs and the
+wall-normal (z) direction with Chebyshev collocation. The state is the
+triple of spectral velocity components on the (Nx, Ny, Nz) grid. The
+incompressibility constraint is enforced by a pressure Poisson solve whose
+per-horizontal-wavenumber Chebyshev matrices are pre-inverted at
+construction, with the no-penetration wall condition folded in.
+
+The pressure solver imposes the mean-pressure gauge by pinning one grid
+point (the zero-wavenumber row), and the wall-normal pressure-gradient
+boundary conditions (from the wall values of w) are applied in
+:meth:`project`.
+
+#### \_\_init\_\_
+
+```python
+def __init__(Nx, Ny, Nz, Lx, Ly, Lz, nu, dtype=jnp.float32)
+```
+
+Precompute wavenumbers, derivative operators, dealiasing mask, and pressure solver.
+
+**Arguments**:
+
+- `Nx` - Number of grid points in x.
+- `Ny` - Number of grid points in y.
+- `Nz` - Number of Chebyshev collocation points in z.
+- `Lx` - Domain length in x.
+- `Ly` - Domain length in y.
+- `Lz` - Domain height in z.
+- `nu` - Kinematic viscosity.
+- `dtype` - Floating dtype for the precomputed operators.
+
+#### fft\_xy
+
+```python
+def fft_xy(f)
+```
+
+Forward FFT of a field over the horizontal (x, y) axes.
+
+**Arguments**:
+
+- `f` - Physical-space field of shape (Nx, Ny, Nz).
+  
+
+**Returns**:
+
+  Spectral field of the same shape.
+
+#### ifft\_xy
+
+```python
+def ifft_xy(f_hat)
+```
+
+Inverse FFT of a field over the horizontal (x, y) axes, taking the real part.
+
+**Arguments**:
+
+- `f_hat` - Spectral field of shape (Nx, Ny, Nz).
+  
+
+**Returns**:
+
+  Physical-space (real) field of the same shape.
+
+#### to\_spectral
+
+```python
+def to_spectral(state: "VelocityState") -> "VelocityState"
+```
+
+Transform a physical-space velocity state to spectral space.
+
+**Arguments**:
+
+- `state` - Physical-space :class:`VelocityState`.
+  
+
+**Returns**:
+
+  Spectral-space :class:`VelocityState`.
+
+#### to\_physical
+
+```python
+def to_physical(state_hat: "VelocityState") -> "VelocityState"
+```
+
+Transform a spectral velocity state to physical space.
+
+**Arguments**:
+
+- `state_hat` - Spectral-space :class:`VelocityState`.
+  
+
+**Returns**:
+
+  Physical-space :class:`VelocityState`.
+
+#### dx\_hat
+
+```python
+def dx_hat(f_hat)
+```
+
+x-derivative of a spectral field (multiplication by i*kx).
+
+**Arguments**:
+
+- `f_hat` - Spectral field.
+  
+
+**Returns**:
+
+  Spectral x-derivative.
+
+#### dy\_hat
+
+```python
+def dy_hat(f_hat)
+```
+
+y-derivative of a spectral field (multiplication by i*ky).
+
+**Arguments**:
+
+- `f_hat` - Spectral field.
+  
+
+**Returns**:
+
+  Spectral y-derivative.
+
+#### dz\_phys
+
+```python
+def dz_phys(f_phys)
+```
+
+First z-derivative of a physical field via the Chebyshev matrix.
+
+**Arguments**:
+
+- `f_phys` - Physical-space field of shape (Nx, Ny, Nz).
+  
+
+**Returns**:
+
+  z-derivative of the same shape.
+
+#### dzz\_phys
+
+```python
+def dzz_phys(f_phys)
+```
+
+Second z-derivative of a physical field via the Chebyshev matrix.
+
+**Arguments**:
+
+- `f_phys` - Physical-space field of shape (Nx, Ny, Nz).
+  
+
+**Returns**:
+
+  Second z-derivative of the same shape.
+
+#### apply\_jets\_v
+
+```python
+def apply_jets_v(v,
+                 Vjets,
+                 z0=1,
+                 jet_thickness=5,
+                 slit_length_x=3.0,
+                 slit_width_y=2.0,
+                 x_span_frac=2 / 3,
+                 nx_jets=6,
+                 ny_jets=4)
+```
+
+Imprint a grid of wall-normal jet velocity profiles onto the v-field.
+
+A periodic array of ``nx_jets x ny_jets`` Gaussian jets centered on the
+bottom wall builds a velocity mask from the per-jet amplitudes in
+``Vjets``; the mask is mean-subtracted (zero net blowing) and written
+into the wall-normal component ``v`` over ``jet_thickness`` layers
+starting at wall layer ``z0``. The wall layers of ``v`` are first set
+to zero.
+
+**Arguments**:
+
+- ``2 - Wall-normal velocity field, shape (Nx, Ny, Nz).
+- ``3 - Jet amplitudes, shape (nx_jets, ny_jets).
+- ``4 - First wall-normal layer the jets penetrate.
+- ``5 - Number of layers the jets span.
+- ``6 - Gaussian width of each jet in x.
+- ``7 - Gaussian width of each jet in y.
+- ``8 - Fraction of the x domain covered by the jet array.
+- ``9 - Number of jets along x.
+- ``0 - Number of jets along y.
+  
+
+**Returns**:
+
+  The modified wall-normal velocity field.
+
+#### enforce\_noslip
+
+```python
+def enforce_noslip(u, v, w, action=None, action_time=50.0, t=0.0)
+```
+
+Apply the wall boundary conditions to a physical-space velocity state.
+
+u and v are forced to zero at both walls. For w, an actuation ramp is
+applied: if an ``action`` is given, the wall-normal jets
+(:meth:`apply_jets_v`) are driven with amplitude proportional to the
+action, scaled by a gain that ramps linearly up over the first 10 time
+units and down over the last 10 before ``action_time``; without an
+action, w is simply set to zero at the walls.
+
+**Arguments**:
+
+- `u` - Streamwise velocity field, shape (Nx, Ny, Nz).
+- `v` - Wall-normal velocity field.
+- `w` - Spanwise velocity field.
+- `action` - Jet control amplitudes, or None for the unactuated case.
+- `action_time` - Total actuation window over which the gain ramps up and down.
+- ``0 - Current time, used for the gain ramp.
+  
+
+**Returns**:
+
+  Tuple ``(u, v, w)`` with the boundary conditions applied.
+
+#### nonlinear\_terms
+
+```python
+def nonlinear_terms(state_hat, action=None, t=0.0, fx=0.0, fy=0.0, fz=0.0)
+```
+
+Evaluate the explicitly treated (nonlinear advection + forcing) terms.
+
+The state is transformed to physical space, wall boundary conditions
+(and jets, if actuated) are applied, and the advective terms
+``u · ∇u`` are computed with spectral x/y derivatives and Chebyshev
+z-derivatives. The result is returned in spectral space with the 2/3
+dealiasing mask applied and the body forcing added.
+
+**Arguments**:
+
+- `state_hat` - Spectral velocity state.
+- `action` - Jet control amplitudes, or None.
+- `t` - Current time (used for the actuation gain ramp).
+- `fx` - x-direction body forcing (scalar or physical-space field).
+- `fy` - y-direction body forcing.
+- `fz` - z-direction body forcing.
+  
+
+**Returns**:
+
+  Spectral :class:`VelocityState` of the nonlinear terms.
+
+#### linear\_terms
+
+```python
+def linear_terms(state_hat, action=None, t=0.0)
+```
+
+Evaluate the implicitly treated (viscous diffusion) term.
+
+Computes ``nu * (∂²u/∂z² - k²u)`` for each component, combining the
+Chebyshev second z-derivative in physical space with the horizontal
+Laplacian applied spectrally.
+
+**Arguments**:
+
+- `state_hat` - Spectral velocity state.
+- `action` - Unused; present for interface compatibility.
+- `t` - Unused; present for interface compatibility.
+  
+
+**Returns**:
+
+  Spectral :class:`VelocityState` of the linear terms.
+
+#### rhs
+
+```python
+def rhs(state_hat, action=None, t=0.0, fx=0.0, fy=0.0, fz=0.0)
+```
+
+Evaluate the full right-hand side as nonlinear + linear terms.
+
+**Arguments**:
+
+- `state_hat` - Spectral velocity state.
+- `action` - Jet control amplitudes, or None.
+- `t` - Current time.
+- `fx` - x-direction body forcing.
+- `fy` - y-direction body forcing.
+- `fz` - z-direction body forcing.
+  
+
+**Returns**:
+
+  Spectral :class:`VelocityState` of the full right-hand side.
+
+#### project
+
+```python
+def project(state_hat, dt, action=None, t=0.0)
+```
+
+Project the state onto the divergence-free (incompressibility) constraint.
+
+Solves the pressure Poisson problem for the divergence error over one
+timestep using the precomputed per-wavenumber inverse Chebyshev
+matrices, with the wall-normal pressure-gradient conditions derived
+from the wall values of w, and the mean-pressure gauge pinned at the
+zero-wavenumber mode. The velocity is corrected by the pressure
+gradient, the boundary conditions (and jets, if actuated) are
+re-applied, and the result is returned in spectral space.
+
+**Arguments**:
+
+- `state_hat` - Spectral velocity state to project.
+- `dt` - Timestep used in the pressure correction.
+- `action` - Jet control amplitudes, or None.
+- `t` - Current time (used for the actuation gain ramp).
+  
+
+**Returns**:
+
+  Projected spectral :class:`VelocityState`.
+
+#### run\_channel\_pseudospectral
+
+```python
+def run_channel_pseudospectral(U0,
+                               V0,
+                               W0,
+                               action,
+                               dt: float,
+                               equation: PseudoSpectralNavierStokes3D,
+                               integrator: RungeKutta4,
+                               nsteps: int = 50,
+                               return_trajectory: bool = False,
+                               checkpoint_steps: bool = True)
+```
+
+Run a channel-flow DNS rollout of ``nsteps`` RK4 steps.
+
+The initial physical fields are transformed to spectral space, advanced
+with ``integrator.rk4_step`` for ``nsteps`` substeps (constant body forcing
+``fx = 2.0``, constant-mass-flux correction toward a bulk velocity of 8.0),
+and returned either as a trajectory of physical-space snapshots or as the
+final state only.
+
+**Arguments**:
+
+- `U0` - Initial streamwise velocity field, shape (Nx, Ny, Nz).
+- `V0` - Initial wall-normal velocity field.
+- ``0 - Initial spanwise velocity field.
+- ``1 - Jet control amplitudes applied at every substep, or None.
+- ``2 - DNS timestep.
+- ``3 - The pseudo-spectral equation (provides transforms).
+- ``4 - The RK4 integrator to step with.
+- ``5 - Number of DNS substeps to run.
+- ``6 - If True, return the full trajectory of physical
+  velocity fields instead of just the final state.
+- ``7 - If True, wrap the step function in ``jax.checkpoint``
+  to trade compute for reduced memory during the scan.
+  
+
+**Returns**:
+
+  If ``return_trajectory``: arrays ``(U, V, W)`` of trajectories with a
+  leading time axis of length ``nsteps``; otherwise the final state&#x27;s
+  physical ``(u, v, w)`` fields.
 
 ## ChannelFlowSpectralEnv Objects
 
@@ -33,4 +517,177 @@ class ChannelFlowSpectralEnv(JAXFlowEnvBase)
 ```
 
 3D turbulent channel flow environment using a pseudo-spectral DNS solver.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env_config: Dict)
+```
+
+Build the equation, integrator, and initial fields for the channel.
+
+Physical/spectral grid parameters are taken from ``env_config`` (with
+defaults matching the previously hardcoded values). Initial velocity
+fields are loaded either from a local directory or from Hugging Face
+(see the source comments for the accepted overrides).
+
+**Arguments**:
+
+- `env_config` - Configuration dictionary; recognized keys include
+  ``Lx``/``Ly``/``Lz`` (domain extents), ``nu`` (viscosity),
+  ``Nx``/``Ny``/``Nz`` (grid resolution, note that non-default
+  values change the JIT-compiled operator shapes and require
+  matching initial-field shapes), ``dtype`` (&quot;float32&quot; or
+  &quot;float64&quot;), ``initial_field_dir`` (local directory containing
+  U/V/W.npy), and the HFDataManager forwarding options
+  ``hf_repo_id``/``cache_dir``/``use_clean_cache``/
+  ``local_fallback_dir``/``hf_token``/``hf_revision``.
+
+#### default\_params
+
+```python
+@property
+def default_params() -> ChannelEnvParams
+```
+
+Default :class:`ChannelEnvParams` for this environment.
+
+#### name
+
+```python
+@property
+def name() -> str
+```
+
+Name of this environment.
+
+#### reset\_env
+
+```python
+def reset_env(key: chex.PRNGKey,
+              params: ChannelEnvParams) -> Tuple[chex.Array, ChannelEnvState]
+```
+
+Reset the channel to the stored initial fields.
+
+**Arguments**:
+
+- `key` - PRNG key (forwarded to the observation function; the reset
+  itself is deterministic).
+- `params` - Channel environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, ChannelEnvState)`` at time 0 with ``terminal=False``.
+
+#### get\_obs
+
+```python
+def get_obs(state: ChannelEnvState,
+            params: ChannelEnvParams,
+            key=None) -> chex.Array
+```
+
+Sample the subsampled U/W observation plane at ``k_det``.
+
+**Arguments**:
+
+- `state` - Current channel environment state.
+- `params` - Channel environment parameters.
+- `key` - Unused; accepted for API compatibility.
+  
+
+**Returns**:
+
+  1D observation array (see :func:`get_obs_spectral_channel`).
+
+#### is\_terminal
+
+```python
+def is_terminal(state: ChannelEnvState,
+                params: ChannelEnvParams) -> jnp.ndarray
+```
+
+Whether the episode has ended (``terminal`` flag or step limit reached).
+
+**Arguments**:
+
+- `state` - Current channel environment state.
+- `params` - Channel environment parameters.
+  
+
+**Returns**:
+
+  Boolean array indicating termination.
+
+#### step\_env
+
+```python
+def step_env(
+    key: chex.PRNGKey, state: ChannelEnvState, action: jnp.ndarray,
+    params: ChannelEnvParams
+) -> Tuple[chex.Array, ChannelEnvState, jnp.ndarray, jnp.ndarray, Dict]
+```
+
+Advance the channel flow by ``params.nsteps`` DNS substeps under the given jet action.
+
+The action is clipped to the parameter bounds and the wall shear stress
+after the rollout is differentiated with respect to the action (via
+``jax.value_and_grad``) to obtain the reward ``-wss`` together with its
+gradient.
+
+**Arguments**:
+
+- `key` - PRNG key (forwarded to the observation function; the dynamics
+  are deterministic).
+- `state` - Current channel environment state.
+- `action` - Jet control input (clipped to ``[min_action, max_action]``).
+- ``1 - Channel environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, next_state, reward, done, info)`` where ``info``
+  contains ``&quot;discount&quot;``. (The reward gradient w.r.t. the action is
+  computed as ``grad_wss`` but is not currently returned.)
+
+#### action\_space
+
+```python
+def action_space(params: Optional[ChannelEnvParams] = None) -> spaces.Box
+```
+
+Return the jet-control action space.
+
+**Arguments**:
+
+- `params` - Channel environment parameters; defaults to
+  ``self.default_params``.
+  
+
+**Returns**:
+
+  Gymnax Box of shape ``(params.action_dim,)`` with bounds
+  ``[params.min_action, params.max_action]``.
+
+#### observation\_space
+
+```python
+def observation_space(params: Optional[ChannelEnvParams] = None) -> spaces.Box
+```
+
+Return the (unbounded) observation space.
+
+**Arguments**:
+
+- `params` - Channel environment parameters; defaults to
+  ``self.default_params``.
+  
+
+**Returns**:
+
+  Gymnax Box of shape
+  ``(params.obs_subsample**2 * params.obs_include_components,)`` with
+  infinite bounds.
 

--- a/docs/docs/api/jax/envs/kolmogorov.md
+++ b/docs/docs/api/jax/envs/kolmogorov.md
@@ -9,9 +9,34 @@ title: hydrogym.jax.envs.kolmogorov
 class FlowConfig(PDEBase)
 ```
 
+Flow configuration for the 2D Kolmogorov flow on a periodic square domain.
+
+Holds the forcing wavenumber ``k``, Reynolds number ``Re``, grid size,
+domain extents, and observation size, and provides the real/Fourier meshes,
+the divergence-free initial condition, the sinusoidal forcing, and the
+observation extraction used by the environment. The state stored in
+``self.vorticity`` (and ``self.state``) is the FFT of the vorticity field.
+
 #### DEFAULT\_OBS\_SIZE
 
 This correlates to a total observation size of 8x8 = 64.
+
+#### \_\_init\_\_
+
+```python
+def __init__(**config)
+```
+
+Read the flow-configuration options and set up the control field.
+
+**Arguments**:
+
+- `**config` - Optional overrides: ``k`` (forcing wavenumber, default 4),
+  ``Re`` (Reynolds number, default 200), ``grid_size`` ((ny, nx)
+  tuple, default (64, 64)), ``domain_x``/``domain_y`` (extent
+  tuples, default (0, 2π)), ``obs_size`` (observation grid side,
+  default 8). Remaining keys are forwarded to
+  :class:``3.
 
 #### load\_mesh
 
@@ -24,6 +49,31 @@ Create jax grid given the desired dimensions and spacing in real space
 **Returns**:
 
   jax meshgrid
+
+#### state
+
+```python
+def state() -> jnp.array
+```
+
+Return the current flow state (the FFT&#x27;d vorticity field).
+
+#### get\_observations
+
+```python
+def get_observations() -> jnp.array
+```
+
+Compute velocity-magnitude observations over the whole stored trajectory.
+
+For each saved vorticity snapshot in ``self.vorticity``, the velocity is
+reconstructed in Fourier space and evaluated on a regularly subsampled
+grid of ``obs_size x obs_size`` points.
+
+**Returns**:
+
+  Array of observations with a leading axis over the trajectory
+  (shape (n_saved, obs_size * obs_size)).
 
 #### load\_fft\_mesh
 
@@ -52,6 +102,14 @@ Initializing with divergence free field specified with the following stream func
 
   fft vorticity field
 
+#### set\_BCs
+
+```python
+def set_BCs()
+```
+
+Apply boundary conditions (no-op; the domain is fully periodic).
+
 #### forcing\_function
 
 ```python
@@ -77,7 +135,16 @@ Sinusoidal forcing function that drives the Kolmogorov flow.
 def evaluate_objective()
 ```
 
-Return a copy of the flow state
+Evaluate the control objective (not implemented; returns None).
+
+#### nu
+
+```python
+@property
+def nu()
+```
+
+Kinematic viscosity ``1 / Re``.
 
 #### num\_inputs
 
@@ -129,6 +196,14 @@ def render(**kwargs)
 
 Plot the current PDE state (called by `gym.Env`)
 
+#### load\_checkpoint
+
+```python
+def load_checkpoint(filename: str)
+```
+
+Load a saved flow state from disk (not implemented).
+
 ## PseudoSpectralNavierStokes2D Objects
 
 ```python
@@ -140,6 +215,19 @@ We transform the 2D Navier-Stokes equation to a vorticity equation:
 ∂/∂t ω + u·∇ω = v ∇²ω + ƒ ;
 ω = - ∇²φ ;
 and solve in Fourier space
+
+#### \_\_init\_\_
+
+```python
+def __init__(flow: FlowConfig)
+```
+
+Store the flow configuration and cache its Fourier and real-space meshes.
+
+**Arguments**:
+
+- `flow` - The :class:`FlowConfig` providing the grid, viscosity, and
+  forcing for the equation.
 
 #### linear\_terms
 
@@ -161,7 +249,7 @@ y_n+1 = y_n / (1-∇tλ).
 #### nonlinear\_terms
 
 ```python
-def nonlinear_terms(omega_hat)
+def nonlinear_terms(omega_hat, control_field=None)
 ```
 
 Computes the explicit (nonlinear) terms in the vorticity equation.
@@ -170,6 +258,7 @@ Uses the stream function to compute velocity components in Fourier space.
 **Arguments**:
 
 - `omega_hat` - fft of vorticity
+- `control_field` - tuple (cfx, cfy) of physical-space forcing arrays, or None
   
 
 **Returns**:
@@ -179,7 +268,7 @@ Uses the stream function to compute velocity components in Fourier space.
 #### control\_term
 
 ```python
-def control_term(omega_hat)
+def control_term(omega_hat, control_field=None)
 ```
 
 Computes the user-specified forcing term of the vorticity equation
@@ -187,7 +276,7 @@ Computes the user-specified forcing term of the vorticity equation
 **Arguments**:
 
 - `omega_hat` - Fourier transformed vorticity term
-- `forcing` - Forcing function as specified by environment or user
+- `control_field` - tuple (cfx, cfy) of physical-space forcing arrays, or None
 
 #### forcing\_term
 
@@ -195,10 +284,221 @@ Computes the user-specified forcing term of the vorticity equation
 def forcing_term()
 ```
 
-Computes the user-specified forcing term of the vorticity equation
+Compute the environmental forcing term of the vorticity equation.
+
+Evaluates the flow&#x27;s ``forcing_function(k, x, y)`` in physical space,
+transforms the (fx, fy) velocity forcing to Fourier space, and takes
+its curl ``2i*pi * (fy_hat * kx - fx_hat * ky)`` to obtain the
+vorticity-space forcing.
+
+**Returns**:
+
+  The spectral forcing term of the same shape as the state, or
+  ``None`` if the flow defines no forcing function.
+
+## KolmogorovFlowState Objects
+
+```python
+@struct.dataclass
+class KolmogorovFlowState(environment.EnvState)
+```
+
+Kolmogorov-flow environment state.
+
+**Attributes**:
+
+- `trajectory` - Saved spectral vorticity snapshots of the last rollout
+  (leading axis over time).
+- `omega_hat` - Final spectral vorticity of the last rollout.
+- `time` - Number of RL steps taken in the current episode.
+- `terminal` - Whether the episode has terminated.
+
+## KolmogorovFlowParams Objects
+
+```python
+@struct.dataclass
+class KolmogorovFlowParams(EnvParams)
+```
+
+Gymnax parameters for the Kolmogorov-flow environment.
+
+**Attributes**:
+
+- `min_action` - Lower bound of each control amplitude.
+- `max_action` - Upper bound of each control amplitude.
+- `min_obs` - Lower bound of the observation space (unbounded).
+- `max_obs` - Upper bound of the observation space (unbounded).
+- `dt` - DNS timestep of the integrator.
+- `action_time` - Physical time simulated per RL step.
+- `save_time` - Time interval between saved trajectory states.
+  k1, k2, k3, k4: Wavenumbers of the four sinusoidal control modes.
+- `action_dim` - Number of control amplitudes.
+- `obs_dim` - Flattened observation size.
+- `max_episode_steps` - Episode length in RL steps.
+- `max_action`0 - Weight of the TKE term in the reward (the action
+  penalty is always weighted at 1).
+- `max_action`1 - Whether gradient information is included (kept for
+  interface compatibility).
+
+## KolmogorovFlow Objects
+
+```python
+class KolmogorovFlow(JAXFlowEnvBase)
+```
+
+2D Kolmogorov-flow Gymnax environment.
+
+Each RL step rolls the pseudo-spectral Navier-Stokes solver forward for
+``action_time`` of physical time with the four sinusoidal control modes
+derived from the action vector. The observation is the time-mean of the
+velocity magnitude over the rollout, sampled on an ``obs_size x obs_size``
+grid; the reward combines the mean turbulent kinetic energy with an
+L1 penalty on the action.
+
+#### \_\_init\_\_
+
+```python
+def __init__(env_config: Optional[Dict] = None,
+             flow_config: Optional[Dict] = None)
+```
+
+Create the flow configuration, equation, and integrator.
 
 **Arguments**:
 
-- `omega_hat` - Fourier transformed vorticity term
-- `forcing` - Forcing function as specified by environment or user
+- `env_config` - Environment options; supports ``dt`` to override the
+  integrator timestep (default: the value in
+  :class:`KolmogorovFlowParams`).
+- `flow_config` - Options forwarded to :class:`FlowConfig` (``k``,
+  ``Re``, ``grid_size``, ``domain_x``, ``domain_y``, ``obs_size``).
+
+#### name
+
+```python
+@property
+def name() -> str
+```
+
+Name of this environment.
+
+#### default\_params
+
+```python
+@property
+def default_params() -> KolmogorovFlowParams
+```
+
+Default parameters, with ``obs_dim`` from the flow&#x27;s ``obs_size`` and the optional ``dt`` override applied.
+
+**Returns**:
+
+  A :class:`KolmogorovFlowParams` instance.
+
+#### action\_space
+
+```python
+def action_space(params: Optional[KolmogorovFlowParams] = None)
+```
+
+Return the (Box) action space bounded by the parameters&#x27; action limits.
+
+**Arguments**:
+
+- `params` - Environment parameters; defaults to ``self.default_params``.
+  
+
+**Returns**:
+
+  Gymnax Box space of shape ``(params.action_dim,)`` with bounds
+  ``[params.min_action, params.max_action]``.
+
+#### observation\_space
+
+```python
+def observation_space(params: KolmogorovFlowParams)
+```
+
+Return the (Box) observation space bounded by the parameters&#x27; observation limits.
+
+**Arguments**:
+
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Gymnax Box space of shape ``(params.obs_dim,)`` with bounds
+  ``[params.min_obs, params.max_obs]``.
+
+#### get\_obs
+
+```python
+def get_obs(state: KolmogorovFlowState,
+            params: KolmogorovFlowParams,
+            key: Optional[chex.PRNGKey] = None) -> chex.Array
+```
+
+Compute the observation as the time-mean velocity magnitude over the rollout.
+
+**Arguments**:
+
+- `state` - Current environment state.
+- `params` - Environment parameters (unused).
+- `key` - Unused; accepted for API compatibility.
+  
+
+**Returns**:
+
+  Flattened array of shape ``(params.obs_dim,)`` (see
+  :meth:`_trajectory_mean_obs`).
+
+#### reset\_env
+
+```python
+def reset_env(key: chex.PRNGKey, params: KolmogorovFlowParams)
+```
+
+Reset the environment: initialize the flow and spin it up unactuated.
+
+The initial divergence-free vorticity field is generated and rolled out
+for one ``action_time`` window with no control; the resulting state
+carries both the final spectral vorticity and the saved trajectory.
+
+**Arguments**:
+
+- `key` - PRNG key (unused; the reset is deterministic).
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, KolmogorovFlowState)`` at RL time 0.
+
+#### step\_env
+
+```python
+def step_env(key: chex.PRNGKey, state: KolmogorovFlowState, action: chex.Array,
+             params: KolmogorovFlowParams)
+```
+
+Advance the environment by one RL step under the given action.
+
+The action is clipped to the parameter bounds, converted into a
+physical-space control field of four sinusoidal modes, and the flow is
+rolled out for one ``action_time`` window. The observation is the
+time-mean velocity magnitude over the rollout and the reward is the
+weighted mean TKE plus the L1 action penalty (negated).
+
+**Arguments**:
+
+- `key` - PRNG key (unused; the dynamics are deterministic).
+- `state` - Current environment state.
+- `action` - Control amplitudes for the four sinusoidal modes.
+- `params` - Environment parameters.
+  
+
+**Returns**:
+
+  Tuple ``(obs, next_state, reward, done, info)`` where ``info``
+  contains ``&quot;discount&quot;`` and ``&quot;mean_tke&quot;``.
 

--- a/docs/docs/api/jax/equation.md
+++ b/docs/docs/api/jax/equation.md
@@ -1,0 +1,168 @@
+---
+sidebar_label: equation
+title: hydrogym.jax.equation
+---
+
+## Equation Objects
+
+```python
+class Equation()
+```
+
+Base class for a PDE right-hand-side defined on a state vector.
+
+Subclasses implement the full right-hand side in :meth:`rhs`, either
+directly or by splitting it into linear and nonlinear parts (see
+:class:`SplitEquation`).
+
+#### \_\_init\_\_
+
+```python
+def __init__(params)
+```
+
+Store the equation parameters.
+
+**Arguments**:
+
+- `params` - Solver/equation parameters (interpreted by subclasses).
+
+#### rhs
+
+```python
+def rhs(state, control)
+```
+
+Evaluate the right-hand side of the equation.
+
+**Arguments**:
+
+- `state` - Current state vector.
+- `control` - Control (actuation) input applied to the flow.
+  
+
+**Returns**:
+
+  Time derivative of the state. Not implemented in the base class.
+
+## SplitEquation Objects
+
+```python
+class SplitEquation(Equation)
+```
+
+Equation whose right-hand side is split into linear and nonlinear terms.
+
+The split exists so implicit-explicit (IMEX) time integrators can treat
+the linear (stiff, typically viscous) term implicitly via
+:meth:`implicit_timestep` in subclasses, and the nonlinear term explicitly.
+
+#### \_\_init\_\_
+
+```python
+def __init__(params)
+```
+
+See :class:`Equation`.
+
+#### linear\_terms
+
+```python
+def linear_terms(state, control)
+```
+
+Evaluate the linear (implicitly treated) term of the equation.
+
+**Arguments**:
+
+- `state` - Current state vector.
+- `control` - Control (actuation) input.
+  
+
+**Returns**:
+
+  Linear contribution to the state derivative. Not implemented here.
+
+#### nonlinear\_terms
+
+```python
+def nonlinear_terms(state, control)
+```
+
+Evaluate the nonlinear (explicitly treated) term of the equation.
+
+**Arguments**:
+
+- `state` - Current state vector.
+- `control` - Control (actuation) input.
+  
+
+**Returns**:
+
+  Nonlinear contribution to the state derivative. Not implemented here.
+
+#### rhs
+
+```python
+def rhs(state, control)
+```
+
+Evaluate the full right-hand side as linear + nonlinear terms.
+
+**Arguments**:
+
+- `state` - Current state vector.
+- `control` - Control (actuation) input.
+  
+
+**Returns**:
+
+  Sum of the linear and nonlinear contributions.
+
+#### forcing
+
+```python
+def forcing()
+```
+
+Evaluate any external forcing added to the right-hand side.
+
+Not implemented in the base class.
+
+## IMEXEquation Objects
+
+```python
+class IMEXEquation(SplitEquation)
+```
+
+Split equation supporting an implicit linear timestep.
+
+Intended for IMEX schemes: the linear term is advanced implicitly via
+:meth:`implicit_timestep` while the nonlinear term is handled explicitly
+by the integrator.
+
+#### \_\_init\_\_
+
+```python
+def __init__(params)
+```
+
+See :class:`SplitEquation`.
+
+#### implicit\_timestep
+
+```python
+def implicit_timestep(state)
+```
+
+Advance the linear part of the equation implicitly by one timestep.
+
+**Arguments**:
+
+- `state` - Current state vector.
+  
+
+**Raises**:
+
+- `NotImplementedError` - Always; subclasses must define the implicit solve.
+

--- a/docs/docs/api/jax/solvers/base.md
+++ b/docs/docs/api/jax/solvers/base.md
@@ -9,6 +9,14 @@ title: hydrogym.jax.solvers.base
 class VelocityState(NamedTuple)
 ```
 
+Three-component velocity (or velocity-spectrum) state, one array per direction.
+
+**Attributes**:
+
+- `u` - x-component; physical or spectral depending on usage.
+- `v` - y-component.
+- `w` - z-component.
+
 #### u
 
 physical or spectral depending on usage
@@ -19,10 +27,34 @@ physical or spectral depending on usage
 class RungeKuttaCrankNicolson(TransientSolver)
 ```
 
+IMEX Crank-Nicolson Runge-Kutta transient solver for a split equation.
+
+Advances an :class:`~hydrogym.jax.equation.IMEXEquation` with the nonlinear
+terms treated explicitly and the linear terms treated implicitly, using a
+low-storage 5-stage scheme; the whole rollout is expressed as a
+``lax.scan`` so it can be JIT-compiled.
+
+#### \_\_init\_\_
+
+```python
+def __init__(flow: PDEBase, dt: float, save_n: int, equation: IMEXEquation,
+             **kwargs)
+```
+
+Initialize the solver.
+
+**Arguments**:
+
+- `flow` - Flow configuration providing the state (used by the base class).
+- `dt` - Timestep size.
+- `save_n` - Number of (inner) steps between saved states.
+- `equation` - The split (IMEX) equation being integrated.
+- `**kwargs` - Ignored; accepted for API compatibility.
+
 #### RK4\_CN
 
 ```python
-def RK4_CN()
+def RK4_CN(control_field=None)
 ```
 
 Crank-Nicolson RK4 implicit-explicit time stepping scheme.
@@ -38,16 +70,148 @@ where g(u,t) is the nonlinear advection term and l(u,t) is the linear diffusion 
 #### step
 
 ```python
-def step(flow: FlowConfig, dt: float, save_n: int, callbacks: Callable)
+def step(flow: PDEBase,
+         dt: float,
+         save_n: int,
+         callbacks: Callable,
+         control_field=None)
 ```
 
-Lax.scan to iteratively apply a function given an initial value
+Build a ``lax.scan`` function that advances a state by ``save_n`` timesteps.
+
+Note this returns the *scan function*, not a stepped state: the caller
+nests it inside an outer scan (see :meth:`solve`).
 
 **Arguments**:
 
-  initialization(grid array): the initial fft vorticity field
-- `steps` _int_ - number of timesteps
-- `save_n` _int_ - save every n steps
-- `ignore_intermediate_steps` _bool_ - if saving every n steps, ignore intermediate steps.
-  this drastically reduces the memory requirements.
+- `flow` - Flow configuration (unused here; the equation carries the
+  dynamics).
+- `dt` - Timestep size (unused here; the one fixed at construction
+  applies).
+- `save_n` - Number of timesteps each inner scan performs.
+- `callbacks` - Unused; per-step callback tracking is not possible
+  inside compiled scans.
+- `control_field` - Optional control input forwarded to the equation&#x27;s
+  nonlinear terms at every step.
+  
+
+**Returns**:
+
+  Callable mapping an initial state to the state ``save_n``
+  timesteps later.
+
+#### solve
+
+```python
+def solve(dt: float,
+          flow: PDEBase,
+          t_span: Tuple[float, float],
+          callbacks: Iterable[CallbackBase] = [],
+          controller: Callable = None,
+          save_n: int = 1,
+          initial_state=None,
+          control_field=None) -> PDEBase
+```
+
+Integrate the equation from t=0 to ``t_span[1]`` with nested lax scans.
+
+The rollout is run as an outer scan of inner scans, each of ``save_n // dt``
+timesteps, so the saved trajectory holds one state per ``save_n`` time
+units. Callbacks are invoked once at the end (per-iteration callback
+tracking is not possible through the compiled scans).
+
+**Arguments**:
+
+- `dt` - Timestep size.
+- `flow` - Flow configuration; also supplies the initial state when
+  ``initial_state`` is None.
+- ``0 - ``(t0, t1)`` integration interval; ``t1`` must be at least 1.
+- ``5 - Callbacks invoked on the flow after the rollout.
+- ``6 - Unused; accepted for API compatibility with the
+  hydrogym solver interface.
+- ``7 - Time interval between saved trajectory states.
+- ``8 - Optional starting state (FFT vorticity field);
+  defaults to ``flow.initialize_state()``.
+- ``1 - Optional control input forwarded to the equation&#x27;s
+  nonlinear terms at every step.
+  
+
+**Returns**:
+
+  Tuple ``(final_state, outputs)`` where ``outputs`` is the stacked
+  trajectory of states at each outer-scan step (also stored on
+  ``flow.vorticity``).
+  
+
+**Raises**:
+
+- ``8 - If the end time in ``t_span`` is less than 1.
+
+## RungeKutta4 Objects
+
+```python
+class RungeKutta4()
+```
+
+Explicit classical 4th-order Runge-Kutta stepper for a velocity state.
+
+Each step evaluates the equation&#x27;s full right-hand side four times,
+projects the result back onto the constraint manifold
+(``equation.project``), and optionally applies a constant-mass-flux
+correction by rescaling the mean streamwise velocity in physical space
+before re-applying the boundary conditions.
+
+#### \_\_init\_\_
+
+```python
+def __init__(equation, dt: float, save_n: int, **kwargs)
+```
+
+Initialize the integrator.
+
+**Arguments**:
+
+- `equation` - Equation object providing ``rhs``, ``project``,
+  ``to_physical``, ``to_spectral`` and ``enforce_noslip``.
+- ``1 - Default timestep used when ``rk4_step`` gets no explicit ``dt``.
+- ``6 - Number of steps between saves (stored; not used by
+  ``rk4_step`` itself).
+- ``9 - Ignored; accepted for API compatibility.
+
+#### rk4\_step
+
+```python
+def rk4_step(state_hat: "VelocityState",
+             dt: float = None,
+             action=None,
+             t: float = 0.0,
+             fx=0.0,
+             fy=0.0,
+             fz=0.0,
+             enforce_const_massflux=True,
+             target_bulk_u=8.0)
+```
+
+Advance the state by one RK4 step, then project and correct mass flux.
+
+**Arguments**:
+
+- `state_hat` - Current state (spectral velocity components).
+- `dt` - Timestep; defaults to the value given at construction.
+- `action` - Control (actuation) input forwarded to the equation&#x27;s rhs,
+  projection, and boundary-condition enforcement.
+- `t` - Current time, used for time-dependent BCs and forcing.
+- `fx` - x-direction body forcing.
+- `fy` - y-direction body forcing.
+- `fz` - z-direction body forcing.
+- `enforce_const_massflux` - If True, rescale the streamwise velocity in
+  physical space so the bulk velocity equals ``target_bulk_u``,
+  then re-apply the no-slip/jet boundary conditions.
+- `dt`0 - Target bulk (domain-mean) streamwise velocity for
+  the mass-flux correction.
+  
+
+**Returns**:
+
+  The new state in spectral form.
 

--- a/docs/docs/api/jaxfluids/env_core.md
+++ b/docs/docs/api/jaxfluids/env_core.md
@@ -3,116 +3,25 @@ sidebar_label: env_core
 title: hydrogym.jaxfluids.env_core
 ---
 
-Core JAXFluids Gym Environment Module
-======================================
-
-This module provides the base environment class for CFD reinforcement learning
-using the JAXFluids solver backend, with Hugging Face Hub integration for
-configuration and environment data management.
-
-## ConfigError Objects
-
-```python
-class ConfigError(Exception)
-```
-
-Exception raised for configuration-related errors.
-
 ## JAXFluidsFlowEnv Objects
 
 ```python
-class JAXFluidsFlowEnv(JAXFluidsEnv)
+class JAXFluidsFlowEnv(HFEnvConfigMixin, JAXFluidsEnv)
 ```
 
 Base JAXFluidsFlowEnv with Hugging Face Hub integration for configuration management.
 
-**Attributes**:
-
-- `environment_name` - Name of the CFD environment configuration.
-- `hf_repo_id` - Hugging Face repository ID (default: `'dynamicslab/HydroGym-environments'`).
-- `env_data_path` - Path to the local environment data directory.
-- `conf` - OmegaConf configuration object loaded from the environment's config file.
-- `use_clean_cache` - Whether to use a clean workspace copy.
-- `local_fallback_dir` - Local directory for offline usage.
-
-#### \_init\_from\_hf
-
-```python
-def _init_from_hf(env_config: dict) -> None
-```
-
-Initialize HF data manager and load environment configuration.
-
-Must be called in the constructor of any subclass before calling `super().__init__`.
-
 **Arguments**:
 
-- `env_config` - Configuration dictionary containing:
-  - `environment_name` (str): Required. Name of the environment.
-  - `hf_repo_id` (str): HF repository ID. Default: `'dynamicslab/HydroGym-environments'`.
-  - `local_fallback_dir` (str): Optional local fallback directory.
-  - `use_clean_cache` (bool): Whether to use clean cache. Default: `True`.
-  - `configuration_file` (str): Optional path to the YAML config file.
+  - environment_name: Required. Name of the environment.
+  - hf_repo_id: Hugging Face repository (default: &#x27;dynamicslab/HydroGym-environments&#x27;)
+  
+  - use_clean_cache: Use clean cache directory (default: True)
+  * True - Creates fresh workspace copy (recommended for production)
+  * False - Uses cached workspace (faster for development/testing)
+  - local_fallback_dir: Local directory for offline usage
+  - configuration_file: Custom path to MAIA config.yaml (optional)
+  
+  :param JAXFluidsEnv: _description_
+  :type JAXFluidsEnv: _type_
 
-**Raises**:
-
-- `ConfigError` - If `environment_name` is missing or no configuration file can be found.
-
-#### \_setup\_environment\_data
-
-```python
-def _setup_environment_data() -> str
-```
-
-Download and set up environment data from HF Hub.
-
-Checks `~/.cache/jaxfluidsgym/<environment_name>` first; falls back to the
-HF data manager if the local cache does not exist.
-
-**Returns**:
-
-  Absolute path to the local environment data directory.
-
-**Raises**:
-
-- `ConfigError` - If environment data cannot be retrieved.
-
-#### \_resolve\_configuration\_file
-
-```python
-def _resolve_configuration_file(config_file_input: Optional[str]) -> Optional[str]
-```
-
-Resolve a configuration file path from various input formats.
-
-**Arguments**:
-
-- `config_file_input` - Can be:
-  - `None`: Auto-detect in the HF environment directory.
-  - Absolute path: Used directly.
-  - Relative path starting with `./` or `../`: Resolved from the current working directory.
-  - Plain filename: Searched first in the current directory, then in the environment directory.
-
-**Returns**:
-
-  Absolute path to the configuration file, or `None` if not found.
-
-**Raises**:
-
-- `ConfigError` - If a specified configuration file path does not exist.
-
-#### \_find\_configuration\_file
-
-```python
-def _find_configuration_file() -> Optional[str]
-```
-
-Auto-detect the configuration file in the environment data directory.
-
-Looks for `config.yaml`, `environment_config.yaml`, `env_config.yaml`,
-`environment.yaml`, `<environment_name>.yaml`, and glob patterns
-`config_*.yaml` / `config_*.yml`, in that order.
-
-**Returns**:
-
-  Absolute path to the configuration file, or `None` if not found.

--- a/docs/docs/api/jaxfluids/envs/nozzle.md
+++ b/docs/docs/api/jaxfluids/envs/nozzle.md
@@ -3,155 +3,27 @@ sidebar_label: nozzle
 title: hydrogym.jaxfluids.envs.nozzle
 ---
 
-Nozzle Environments for Shock Vector Control
-=============================================
-
-This module implements 2D and 3D nozzle environments for thrust vector control (TVC)
-via secondary injection (shock vector control). Both environments expose a Gymnasium
-action space of injector pressure ratios and return observations containing the current
-and target thrust angles, with optional wall-pressure probes.
-
-## NozzleBase Objects
-
-```python
-class NozzleBase(JAXFluidsFlowEnv)
-```
-
-Abstract base class for nozzle TVC environments.
-
-Subclasses must define the class variables `SPEC` and `TARGET_FNS` and implement
-the abstract methods `_compute_probe_locations`, `_get_reward`, `_plot_flow_field`,
-and `_plot_observations`.
-
-**Class variables**:
-
-- `SPEC` (`TVCSpec`) - Environment specification (dimension, actuator count, geometry, …).
-- `TARGET_FNS` (`dict[str, TargetThrustAngleFn]`) - Named target-angle functions keyed by string.
-
-**Attributes**:
-
-- `num_actuators` - Number of secondary-injection actuators.
-- `secondary_pressure_ratio` - Injector secondary-to-nozzle pressure ratio (0.7–0.9).
-- `resolution` - Spatial grid resolution (`'coarse'` or `'fine'`).
-- `target_fn` - Active target-angle callable selected via `env_config['target_fn']`.
-- `is_pressure_probes` - Whether wall-pressure probes are included in the observation.
-- `is_scale_observations` - Whether thrust angles and pressures are normalised.
-- `injector_geometry` (`InjectorGeometry`) - Position, width and count of the injectors.
-- `pressure_ratios` (`PressureRatios`) - Nozzle and secondary pressure ratios.
-
-#### \_\_init\_\_
-
-```python
-def __init__(env_config: dict) -> None
-```
-
-Initialise the nozzle environment from a configuration dictionary.
-
-Calls `_init_from_hf` to download environment data, then constructs the
-JAXFluids simulation and Gymnasium spaces.
-
-**Arguments**:
-
-- `env_config` - Configuration dictionary. Keys consumed by this class:
-  - `secondary_pressure_ratio` (float): Default `0.7`. Must be in [0.7, 0.9].
-  - `resolution` (str): `'coarse'` or `'fine'`. Default `'fine'`.
-  - `ngpus` (int): Number of GPUs. Default `1`.
-  - `is_pressure_probes` (bool): Include pressure-probe observations. Default `False`.
-  - `is_scale_observations` (bool): Normalise observations. Default `True`.
-  - `target_fn` (str): Key in `TARGET_FNS`. Default `'sine'`.
-  - Plus any keys required by `JAXFluidsFlowEnv._init_from_hf`.
-
-#### compute\_obs
-
-```python
-def compute_obs(jxf_buffers: JaxFluidsBuffers) -> ObsData
-```
-
-Compute the current observation from simulation state.
-
-Dispatches to `_compute_obs` via `jax.pmap` in multi-GPU mode or
-`jax.jit` in single-device mode.
-
-**Arguments**:
-
-- `jxf_buffers` - Current JAXFluids simulation buffers.
-
-**Returns**:
-
-  `ObsData` named tuple with `thrust_angle`, `target_angle`, and optionally `pressure_probes`.
-
-#### compute\_thrust\_angle
-
-```python
-def compute_thrust_angle(jxf_buffers: JaxFluidsBuffers) -> Array
-```
-
-Compute the current thrust vector angle from nozzle exit fluxes.
-
-Returns a scalar (2-D) or a 2-element array of (pitch, yaw) angles (3-D),
-both in radians.
-
-**Arguments**:
-
-- `jxf_buffers` - Current JAXFluids simulation buffers.
-
-**Returns**:
-
-  Thrust angle in radians. Shape `()` for 2D, `(2,)` for 3D.
-
-#### compute\_pressure\_probes
-
-```python
-def compute_pressure_probes(jxf_buffers: JaxFluidsBuffers) -> Array
-```
-
-Sample static pressure at the pre-computed probe locations.
-
-**Arguments**:
-
-- `jxf_buffers` - Current JAXFluids simulation buffers.
-
-**Returns**:
-
-  Pressure values at each probe, shape `(num_probes,)`.
-
-#### render
-
-```python
-def render() -> None
-```
-
-Render the current environment state.
-
-Calls `_plot_flow_field` and `_plot_observations` according to the active
-`render_mode`. No-ops when `render_mode` is `None`.
-
 ## Nozzle2D Objects
 
 ```python
 class Nozzle2D(NozzleBase)
 ```
 
-2D nozzle environment for shock vector control.
+Nozzle2D environment for shock vector control.
 
-Two fixed actuators are placed on the upper and lower nozzle walls.
-The action space is `Box(0, 1, shape=(2,))` (injector pressure ratios).
-The observation contains the scalar thrust angle and its target (radians or
-normalised to [-1, 1]) and optionally four wall-pressure probes.
+For the 2D nozzle, two actuators are present: one located on the upper
+side of the nozzle, and one located at the lower side of the nozzle.
 
-**Configuration keys** (passed as `env_config`):
+**Arguments**:
 
-- `secondary_pressure_ratio` (float): Default `0.7`.
-- `resolution` (str): `'coarse'` or `'fine'`. Default `'fine'`.
-- `ngpus` (int): Default `1`.
-- `is_pressure_probes` (bool): Default `False`.
-- `is_scale_observations` (bool): Default `True`.
-- `target_fn` (str): `'sine'` or `'step'`. Default `'sine'`.
-
-**Target functions**:
-
-- `'sine'` — sinusoidal target with amplitude 10° and period 4 ms, onset at 0.5 ms.
-- `'step'` — step to 5° at 0.5 ms.
+  - secondary_pressure_ratio: Optional. Float, must be between 0.7 and 0.9.
+  Defaults to 0.7.
+  - resolution: Optional. Spatial resolution of the environment. Choose either &#x27;coarse&#x27; or &#x27;fine&#x27;.
+  - ngpus: Optional. Number of GPUs for running the environment.
+  - is_pressure_probes: Optional. Boolean indicating whether pressure probes
+  are part of the observation
+  - is_scale_observations: Optional. Boolean indicating whether observations are scaled to [0, 1].
+  - target_fn: Optional. Target thrust vector function. Choose either &#x27;sine&#x27; or &#x27;step&#x27;.
 
 ## Nozzle3D Objects
 
@@ -159,25 +31,21 @@ normalised to [-1, 1]) and optionally four wall-pressure probes.
 class Nozzle3D(NozzleBase)
 ```
 
-3D nozzle environment for shock vector control.
+Nozzle3D environment for shock vector control.
 
-The number of actuators is user-configurable (4–12) and distributed uniformly
-around the nozzle circumference.
-The action space is `Box(0, 1, shape=(num_actuators,))`.
-The observation contains pitch and yaw thrust angles (radians or normalised)
-and optionally 12 wall-pressure probes.
+For the 3D nozzle, the number of actuators can be set by the user. The minimum number of
+actuators is 4, and the maximum number is 12. The actuators are distributed uniformly over
+the diameter.
 
-**Configuration keys** (passed as `env_config`):
+**Arguments**:
 
-- `num_actuators` (int): Required. Must be in [4, 12].
-- `secondary_pressure_ratio` (float): Default `0.7`.
-- `resolution` (str): `'coarse'` or `'fine'`. Default `'fine'`.
-- `ngpus` (int): Default `1`.
-- `is_pressure_probes` (bool): Default `False`.
-- `is_scale_observations` (bool): Default `True`.
-- `target_fn` (str): `'sine'` or `'step'`. Default `'sine'`.
+  - num_actuators: Required. Integer number of actuators. Must be between 4 and 12.
+  - secondary_pressure_ratio: Optional. Float, must be between 0.7 and 0.9.
+  Defaults to 0.7.
+  - resolution: Optional. Spatial resolution of the environment. Choose either &#x27;coarse&#x27; or &#x27;fine&#x27;.
+  - ngpus: Optional. Number of GPUs for running the environment.
+  - is_pressure_probes: Optional. Boolean indicating whether pressure probes
+  are part of the observation
+  - is_scale_observations: Optional. Boolean indicating whether observations are scaled to [0, 1].
+  - target_fn: Optional. Target thrust vector function. Choose either &#x27;sine&#x27; or &#x27;step&#x27;.
 
-**Target functions**:
-
-- `'sine'` — sinusoidal pitch with amplitude 10° and period 4 ms, onset at 1 ms; yaw held at 0°.
-- `'step'` — step pitch to 5° at 1 ms; yaw held at 0°.

--- a/docs/docs/api/jaxfluids/utils/nozzle.md
+++ b/docs/docs/api/jaxfluids/utils/nozzle.md
@@ -3,36 +3,15 @@ sidebar_label: nozzle
 title: hydrogym.jaxfluids.utils.nozzle
 ---
 
-Nozzle Utility Dataclasses and Functions
-=========================================
-
-This module provides dataclasses, named tuples, type aliases, and functions used
-by the JAXFluids nozzle environments for geometry, physics, and visualisation.
-
-## Type Aliases
-
-```python
-TargetThrustAngle = Array | float
-TargetThrustAngleFn = Callable[[Array | float], TargetThrustAngle]
-```
-
 ## NozzleGeometry Objects
 
 ```python
 @dataclass(frozen=True, slots=True)
-class NozzleGeometry
+class NozzleGeometry()
 ```
 
-Fixed nozzle geometry based on Das et al. 2025 AIAA.
-
-Stores key vertex coordinates (A–H) and the throat radius R as class-level
-defaults. The dataclass is frozen and therefore hashable.
-
-**Fields**:
-
-- `A`, `B`, `C`, `D`, `E`, `F`, `G`, `H` (`tuple[float, float]`) - Nozzle wall vertices.
-- `R` (`float`) - Throat radius.
-- `UPPER_EDGE` (`float`) - Upper domain edge.
+Fixed nozzle geometry based on the publication
+Das et al. 2025 AIAA
 
 #### area\_ratio\_inlet
 
@@ -40,331 +19,55 @@ defaults. The dataclass is frozen and therefore hashable.
 def area_ratio_inlet(dim: int) -> float
 ```
 
-Compute the ratio of the inlet area to the throat area.
-
-**Arguments**:
-
-- `dim` - Dimensionality: `2` for planar, `3` for axisymmetric.
-
-**Returns**:
-
-  Area ratio (linear for 2-D, squared for 3-D).
-
-**Raises**:
-
-- `ValueError` - If `dim` is not 2 or 3.
-
-#### D\_exit
-
-```python
-@property
-def D_exit() -> float
-```
-
-Exit diameter `2 * H[1]`.
-
-#### D\_throat
-
-```python
-@property
-def D_throat() -> float
-```
-
-Throat diameter `2 * R`.
+Computes the ratio of the inlet area
+to the throat area.
 
 ## InjectorGeometry Objects
 
 ```python
 @dataclass(frozen=True, slots=True)
-class InjectorGeometry
+class InjectorGeometry()
 ```
 
-Injector position and size parameters.
+#### X
 
-**Fields**:
+position
 
-- `X` (`float`) - Relative axial position of the injector along the nozzle wall.
-- `IW` (`float`) - Injector width (metres).
-- `N` (`int`) - Number of injectors.
+#### IW
 
-## InjectorPlaneParameters Objects
+width
 
-```python
-@dataclass(frozen=True, slots=True)
-class InjectorPlaneParameters
-```
+#### N
 
-Pre-computed local coordinate frames for each injector.
-
-**Fields**:
-
-- `positions` (`Array`) - Shape `(N, 3)`. Injector centre coordinates.
-- `tangents` (`Array`) - Shape `(N, 3)`. Nozzle-wall tangent at each injector.
-- `normals` (`Array`) - Shape `(N, 3)`. Inward surface normal at each injector.
+count
 
 ## PressureRatios Objects
 
 ```python
 @dataclass(frozen=True, slots=True)
-class PressureRatios
+class PressureRatios()
 ```
 
-Nozzle operating pressure ratios.
+#### NPR
 
-**Fields**:
+nozzle pressure ratio
 
-- `NPR` (`float`) - Nozzle pressure ratio (total-to-ambient).
-- `SPR` (`float`) - Secondary (injector) pressure ratio.
+#### SPR
 
-## ObsData Objects
-
-```python
-class ObsData(NamedTuple)
-```
-
-Structured observation returned by `NozzleBase.compute_obs`.
-
-**Fields**:
-
-- `thrust_angle` (`Array`) - Current thrust angle(s) in radians.
-- `target_angle` (`Array`) - Target thrust angle(s) in radians.
-- `pressure_probes` (`Array | None`) - Wall-pressure probe values, or `None`.
-
-## TVCSpec Objects
-
-```python
-@dataclass(frozen=True, slots=True)
-class TVCSpec
-```
-
-Specification for a Thrust Vector Control environment.
-
-**Fields**:
-
-- `dim` (`int`) - Problem dimensionality (2 or 3).
-- `grid_resolutions` (`tuple[str, ...]`) - Allowed resolution strings. Default `('coarse', 'fine')`.
-- `fixed_num_actuators` (`int | None`) - Fixed actuator count (2-D nozzle). Mutually exclusive with min/max.
-- `min_num_actuators` (`int | None`) - Minimum actuator count (3-D nozzle).
-- `max_num_actuators` (`int | None`) - Maximum actuator count (3-D nozzle).
-- `ambient_pressure` (`float`) - Ambient static pressure in Pa. Default `1e5`.
-- `ambient_temperature` (`float`) - Ambient temperature in K. Default `300.0`.
-- `specific_gas_constant` (`float`) - Specific gas constant in J/(kg·K). Default `287.14`.
-- `specific_heat_ratio` (`float`) - Ratio of specific heats. Default `1.4`.
-- `nozzle_pressure_ratio` (`float`) - Total-to-ambient pressure ratio. Default `4.6`.
-- `nozzle_geometry` (`NozzleGeometry`) - Nozzle wall geometry.
-- `injector_x` (`float`) - Relative axial injector position. Default `0.789`.
-- `injector_width` (`float`) - Injector slot width in metres. Default `0.002032`.
-- `t_end` (`float`) - Episode duration in seconds. Default `1e-2`.
-
-#### p0
-
-```python
-@property
-def p0() -> float
-```
-
-Total reservoir pressure: `nozzle_pressure_ratio * ambient_pressure`.
-
-## TVCEnvOptions Objects
-
-```python
-@dataclass(frozen=True, slots=True)
-class TVCEnvOptions
-```
-
-Parsed and validated environment options produced by `build_tvc_env_options`.
-
-**Fields**:
-
-- `num_actuators` (`int`)
-- `secondary_pressure_ratio` (`float`)
-- `resolution` (`str`)
-- `ngpus` (`int`)
-- `is_pressure_probes` (`bool`)
-- `is_scale_observations` (`bool`)
-- `target_fn` (`TargetThrustAngleFn`)
-
-## TVCRuntimeSetup Objects
-
-```python
-@dataclass(frozen=True, slots=True)
-class TVCRuntimeSetup
-```
-
-Runtime file paths and pre-loaded setup dictionaries for the JAXFluids simulation.
-
-**Fields**:
-
-- `env_name` (`str`) - Constructed environment name string (e.g. `'Nozzle2D_fine'`).
-- `env_dir` (`Path`) - Directory containing all environment files.
-- `case_setup_dict` (`dict`) - Loaded `jxf_case_setup.json` (with GPU decomposition applied).
-- `numerical_setup_dict` (`dict`) - Loaded `jxf_numerical_setup.json`.
-- `restart_file_path` (`Path`) - Path to `restart.h5`.
-
-## Functions
-
-#### build\_tvc\_env\_options
-
-```python
-def build_tvc_env_options(*,
-                          env_config: dict,
-                          spec: TVCSpec,
-                          target_fns: dict[str, TargetThrustAngleFn],
-                          cls_name: str) -> TVCEnvOptions
-```
-
-Parse and validate environment configuration against a `TVCSpec`.
-
-**Arguments**:
-
-- `env_config` - Raw environment configuration dictionary.
-- `spec` - `TVCSpec` describing the environment constraints.
-- `target_fns` - Available target-angle functions keyed by name.
-- `cls_name` - Class name used in error messages.
-
-**Returns**:
-
-  Validated `TVCEnvOptions`.
-
-**Raises**:
-
-- `ValueError` - If any configuration value is outside the allowed range.
-
-#### build\_tvc\_runtime\_setup
-
-```python
-def build_tvc_runtime_setup(*,
-                            base_path: Path,
-                            dim: int,
-                            resolution: str,
-                            ngpus: int) -> TVCRuntimeSetup
-```
-
-Load JAXFluids case and numerical setup files and return a `TVCRuntimeSetup`.
-
-**Arguments**:
-
-- `base_path` - Root directory that contains the environment files.
-- `dim` - Dimensionality (2 or 3).
-- `resolution` - Grid resolution string (e.g. `'fine'`).
-- `ngpus` - Number of GPUs; sets the x-axis decomposition in `case_setup_dict`.
-
-**Returns**:
-
-  `TVCRuntimeSetup` with all paths validated and dicts loaded.
-
-**Raises**:
-
-- `FileNotFoundError` - If any required file (`jxf_case_setup.json`, `jxf_numerical_setup.json`, `restart.h5`) is missing.
+secondary pressure ratio
 
 #### compute\_thrust
 
 ```python
-def compute_thrust(primitives: Array,
-                   p_infty: float,
-                   apertures_x: Array,
-                   cell_centers: tuple[Array, ...],
-                   cell_sizes: tuple[Array, ...]) -> tuple[Array, Array, Array]
+def compute_thrust(
+        primitives: Array, p_infty: float, apertures_x: Array,
+        cell_centers: tuple[Array, ...],
+        cell_sizes: tuple[Array, ...]) -> tuple[Array, Array, Array]
 ```
 
-Compute integrated nozzle thrust from the primitive flow state.
+Computes the thrust of the nozzle.
 
-Uses the momentum-flux and pressure-area formulation at the nozzle exit plane:
-
-```
 F_x = mdot_e * u_e + (p_e - p_infty) * A_e
 F_y = mdot_e * v_e
 F_z = mdot_e * w_e
-```
 
-**Arguments**:
-
-- `primitives` - Primitive variables array, shape `(Np, Nx, Ny, Nz)`.
-- `p_infty` - Ambient static pressure (Pa).
-- `apertures_x` - X-direction aperture fractions from the level-set solver.
-- `cell_centers` - Tuple of 1-D coordinate arrays `(x, y, z)`.
-- `cell_sizes` - Tuple of 1-D cell-size arrays `(dx, dy, dz)`.
-
-**Returns**:
-
-  `(thrust, mdot_throat, mdot_exit)` — thrust vector `(3,)` and scalar mass-flow rates.
-
-#### initialize\_injector\_flux\_fn
-
-```python
-def initialize_injector_flux_fn(injector_geometry: InjectorGeometry,
-                                pressure_ratios: PressureRatios,
-                                p_infty: float,
-                                T_infty: float,
-                                specific_heat_ratio: float,
-                                specific_gas_constant: float,
-                                sim_manager: SimulationManager) -> Callable
-```
-
-Build the interface-flux callable for secondary injection.
-
-Closes over the injector geometry and thermodynamic constants to produce a
-JAX-compatible callable that computes mass, momentum, and energy fluxes for
-each injector given the current actuator commands (values in [0, 1]).
-
-**Arguments**:
-
-- `injector_geometry` - Injector position, width, and count.
-- `pressure_ratios` - Nozzle and secondary pressure ratios.
-- `p_infty` - Ambient static pressure (Pa).
-- `T_infty` - Ambient temperature (K).
-- `specific_heat_ratio` - Ratio of specific heats γ.
-- `specific_gas_constant` - Specific gas constant R in J/(kg·K).
-- `sim_manager` - Active JAXFluids `SimulationManager` (provides domain info).
-
-**Returns**:
-
-  `compute_interface_flux(primitives, interface_length, normal, mesh_grid, actuator)`
-  callable compatible with JAXFluids `InterfaceFluxCallablesSetup`.
-
-#### plot\_flowfield\_3d
-
-```python
-def plot_flowfield_3d(primitives: ndarray,
-                      levelset: ndarray,
-                      cell_centers: tuple[ndarray, ...],
-                      cell_sizes: tuple[ndarray, ...],
-                      nozzle_pressure: float,
-                      injector_geometry: InjectorGeometry,
-                      specific_heat_ratio: float) -> pv.Plotter
-```
-
-Render a 3-D nozzle flow field using PyVista.
-
-Produces an off-screen `pv.Plotter` with Mach-number slices, a pressure-
-coloured nozzle surface, and Schlieren contours.
-
-**Arguments**:
-
-- `primitives` - Primitive variables array (NumPy), shape `(5, Nx, Ny, Nz)`.
-- `levelset` - Level-set field (NumPy), shape `(Nx, Ny, Nz)`.
-- `cell_centers` - Tuple `(x, y, z)` of 1-D coordinate arrays.
-- `cell_sizes` - Tuple `(dx, dy, dz)` of 1-D size arrays.
-- `nozzle_pressure` - Total nozzle pressure used for normalisation.
-- `injector_geometry` - Injector position, width, and count.
-- `specific_heat_ratio` - Ratio of specific heats γ.
-
-**Returns**:
-
-  Configured `pv.Plotter` instance (off-screen, 3000×2200 px).
-
-#### clip\_grids
-
-```python
-def clip_grids(grid, grid_levelset)
-```
-
-Clip two `pv.RectilinearGrid` objects to the nozzle interior region.
-
-#### plot\_slice
-
-```python
-def plot_slice(grid_levelset, grid) -> pv.Plotter
-```
-
-Compose the final PyVista scene from clipped grids.

--- a/docs/docs/api/maia/env_core.md
+++ b/docs/docs/api/maia/env_core.md
@@ -9,18 +9,10 @@ Core MaiaGym Environment Module
 This module provides the base environment class for CFD reinforcement learning
 with Hugging Face Hub integration for configuration management.
 
-## ConfigError Objects
-
-```python
-class ConfigError(Exception)
-```
-
-Exception raised for configuration-related errors.
-
 ## MaiaFlowEnv Objects
 
 ```python
-class MaiaFlowEnv(gym.Env)
+class MaiaFlowEnv(HFEnvConfigMixin, gym.Env)
 ```
 
 Base MaiaFlowEnv with Hugging Face Hub integration for configuration management.
@@ -64,11 +56,19 @@ Initialize the MaiaFlowEnv environment.
   &#x27;none&#x27;, &#x27;customized&#x27;.
   - obs_loc (list): Required if strategy is &#x27;customized&#x27;.
   - obs_scale (list): Required if strategy is &#x27;customized&#x27;.
+  - nproc (int): Optional. Expected number of m-AIA solver
+  ranks in the MPMD launch. When given, validated against
+  the actual MPI world at construction time; a mismatch
+  raises a clear ``RuntimeError`` naming the fix, instead
+  of failing confusingly downstream. Omit to skip this
+  check (default).
   
 
 **Raises**:
 
 - `ConfigError` - If required configuration is missing or invalid.
+- `RuntimeError` - If ``nproc`` is given and does not match the
+  actual number of m-AIA solver ranks in the MPMD job.
 
 #### get\_environment\_files\_info
 
@@ -195,6 +195,9 @@ Advance the state of the environment by one step.
 **Returns**:
 
   Tuple of (observation, reward, terminated, truncated, info).
+  terminated is always False (no in-band physics-failure signal);
+  truncated becomes True once the step budget
+  (max_episode_steps) is reached.
 
 #### reset
 
@@ -365,7 +368,9 @@ Factory function to create any MaiaGym environment from Hugging Face Hub.
 
 ```python
 def list_available_environments(
-        hf_repo_id: str = "dynamicslab/HydroGym-environments") -> List[str]
+        hf_repo_id: str = "dynamicslab/HydroGym-environments",
+        hf_token: Optional[str] = None,
+        hf_revision: Optional[str] = None) -> List[str]
 ```
 
 List all available environments from HF Hub.
@@ -373,6 +378,8 @@ List all available environments from HF Hub.
 **Arguments**:
 
 - `hf_repo_id` - Hugging Face repository ID.
+- `hf_token` - Hugging Face access token (private/gated repos; ``None`` = ambient auth).
+- `hf_revision` - Git revision to pin the file listing to.
   
 
 **Returns**:

--- a/docs/docs/api/maia/mpmd_interface.md
+++ b/docs/docs/api/maia/mpmd_interface.md
@@ -47,17 +47,36 @@ Initialize the MaiaInterface.
 #### init\_comm
 
 ```python
-def init_comm(comm_world: MPI.Comm) -> None
+def init_comm(comm_world: MPI.Comm, nproc: Optional[int] = None) -> None
 ```
 
 Initialize MPI communication with m-AIA.
 
 Sets up the communicators and determines the root ranks for both
-the Python controller and the m-AIA solver.
+the Python controller and the m-AIA solver. The split math itself
+lives in `hydrogym.core_external.split_comm_by_appnum` (shared
+module for MPMD world-split strategies, audit Task 3.5); only the
+attribute assignment stays here.
 
 **Arguments**:
 
 - `comm_world` - MPI communicator, typically MPI.COMM_WORLD.
+- `nproc` - Expected number of m-AIA solver ranks. When given,
+  validated against the actual remote-app rank count
+  (``comm_world.Get_size() - appNoRanks``, i.e. every world
+  rank not part of this app) and a clear ``RuntimeError`` is
+  raised on mismatch, mirroring
+  ``hydrogym.core_external.mpi_split``&#x27;s existing check for
+  Nek (audit Finding 2.5 / Verification Addendum Finding B:
+  MAIA previously had zero launch-config mismatch detection).
+  ``None`` (default) skips validation, preserving prior
+  behavior exactly.
+  
+
+**Raises**:
+
+- `comm_world`1 - If ``nproc`` is given and does not match the
+  actual number of m-AIA solver ranks in the MPMD job.
 
 #### continueRun
 

--- a/docs/docs/api/maia/workspace.md
+++ b/docs/docs/api/maia/workspace.md
@@ -30,7 +30,9 @@ def __init__(environment_name: str,
              hf_repo_id: str = "dynamicslab/HydroGym-environments",
              local_fallback_dir: Optional[str] = None,
              use_clean_cache: bool = True,
-             solver_type: Optional[str] = None)
+             solver_type: Optional[str] = None,
+             hf_token: Optional[str] = None,
+             hf_revision: Optional[str] = None)
 ```
 
 Initialize the MAIA workspace.
@@ -43,6 +45,8 @@ Initialize the MAIA workspace.
 - `local_fallback_dir` - Optional local fallback directory.
 - `use_clean_cache` - Whether to use clean cache for HF downloads.
 - `solver_type` - Solver profile key (``&#x27;MAIA_LB&#x27;`` or ``&#x27;MAIA_STRCTRD&#x27;``).
+- `work_dir`0 - Hugging Face access token (private/gated repos; ``None`` = ambient auth).
+- `work_dir`3 - Git revision to pin HF downloads/listings to.
   Auto-detected from sentinel files if ``None`` (recommended).
   Defaults to ``&#x27;MAIA_LB&#x27;`` as fallback for legacy environments.
 

--- a/docs/docs/api/nek/__init__.md
+++ b/docs/docs/api/nek/__init__.md
@@ -7,7 +7,7 @@ HydroGym Nek5000 backend.
 
 Initialization Patterns:
 1. MAIA pattern (recommended):
-env = NekEnv.from_hf(&#x27;MiniChannel_Re180&#x27;, nproc=10)
+env = NekEnv.from_hf(&#x27;TCFmini_3D_Re180&#x27;, nproc=10)
 
 2. Legacy pattern (deprecated):
 conf = OmegaConf.load(&#x27;config.yaml&#x27;)

--- a/docs/docs/api/nek/env.md
+++ b/docs/docs/api/nek/env.md
@@ -10,36 +10,23 @@ Supports two initialization patterns:
 1. MAIA pattern (recommended): env = NekEnv.from_hf(&#x27;EnvName&#x27;, nproc=10)
 2. Legacy pattern: env = NekEnv(conf=config_obj)
 
-## ConfigError Objects
+## NekDivergenceError Objects
 
 ```python
-class ConfigError(Exception)
+class NekDivergenceError(RuntimeError)
 ```
 
-Exception raised for configuration-related errors.
+Raised when the Nek simulation&#x27;s CFL number blows up during evolve.
 
-#### mpi\_split
-
-```python
-def mpi_split(comm_world: MPI.Comm, nproc: Optional[int] = None) -> MPI.Comm
-```
-
-Split MPI world into master/worker inter-communicator.
-
-**Arguments**:
-
-- `comm_world` - MPI communicator
-- `nproc` - Expected number of Nek workers (for validation)
-  
-
-**Returns**:
-
-  Inter-communicator between controller and workers
+Replaces the former bare ``exit()`` so the failure is catchable by RL
+loops and gym wrappers. By the time this is raised the solver side has
+already been shut down cleanly (TERMN sent, intercomm freed, MPI
+finalized) -- the environment is not usable afterwards.
 
 ## NekEnv Objects
 
 ```python
-class NekEnv(gym.Env)
+class NekEnv(HFEnvConfigMixin, ExternalProcessEnvMixin, gym.Env)
 ```
 
 Core Nek5000 environment with Gymnasium interface.
@@ -52,7 +39,7 @@ Supports two initialization patterns:
 
 1. MAIA pattern (recommended):
 env = NekEnv.from_hf(
-&#x27;MiniChannel_Re180&#x27;,
+&#x27;TCFmini_3D_Re180&#x27;,
 nproc=10,
 hostfile=&#x27;&#x27;,
 )
@@ -65,20 +52,25 @@ Args (MAIA pattern via env_config):
 environment_name: Name of environment on HuggingFace
 nproc: Number of MPI workers for Nek (required)
 hostfile: MPI hostfile path (default: &#x27;&#x27;)
+mpi_bind_to: MPI bind policy passed to mpirun via MPI.Info
+(default: &#x27;none&#x27; = unbound; e.g. &#x27;core&#x27; binds ranks to cores)
 hf_repo_id: HuggingFace repository (default: &#x27;dynamicslab/HydroGym-environments&#x27;)
 use_clean_cache: Use fresh workspace (default: True)
 local_fallback_dir: Local directory for offline usage
 configuration_file: Override config file path
 run_root: Root directory for outputs (default: &#x27;runs&#x27;)
 run_name: Name for this run (default: &#x27;&#x27; = no subdirectory, use run_root directly)
-reward_agg: Reward aggregation method (&quot;mean&quot; or &quot;sum&quot;)
+reward_agg: Reward aggregation method (&quot;mean&quot;, &quot;sum&quot;, or &quot;median&quot;) - legacy
+name, kept working
+reward_aggregation: Same as reward_agg, primary name (matches core.py /
+Firedrake); takes precedence when both are given
 ... (runtime overrides for config parameters)
 
 Args (Legacy pattern):
 conf: Configuration object (OmegaConf)
 run_root: Root directory for run outputs
 run_name: Name for this run (defaults to MPI rank)
-reward_agg: How to aggregate per-actuator rewards (&quot;mean&quot; or &quot;sum&quot;)
+reward_agg: How to aggregate per-actuator rewards (&quot;mean&quot;, &quot;sum&quot;, or &quot;median&quot;)
 
 #### \_\_init\_\_
 
@@ -88,6 +80,7 @@ def __init__(conf: Optional[Config] = None,
              run_root: str = ".",
              run_name: Optional[str] = None,
              reward_agg: str = "mean",
+             reward_aggregation: Optional[str] = None,
              **kwargs)
 ```
 
@@ -101,6 +94,15 @@ Initialize NekEnv with either legacy conf or MAIA env_config pattern.
 - `run_name` - Run name (auto-generate if None)
 - `reward_agg` - Reward aggregation method
 - `**kwargs` - Additional parameters (for backward compatibility)
+  
+
+**Raises**:
+
+- `ValueError` - If both &#x27;conf&#x27; and &#x27;env_config&#x27; are given, or an invalid
+  reward aggregation is requested.
+- `UserWarning` - If **kwargs is non-empty -- these are accepted for
+  backward compatibility but have NO effect; runtime overrides
+  belong in env_config (see NekEnv.from_hf).
 
 #### from\_hf
 
@@ -117,7 +119,7 @@ Create environment from HuggingFace Hub (MAIA pattern).
 
 **Arguments**:
 
-- `environment_name` - Name of the environment (e.g., &#x27;MiniChannel_Re180&#x27;)
+- `environment_name` - Name of the environment (e.g., &#x27;TCFmini_3D_Re180&#x27;)
 - `nproc` - Number of MPI workers for Nek (required)
 - `hostfile` - MPI hostfile path (default: &#x27;&#x27;)
 - `**kwargs` - Additional env_config parameters:
@@ -127,12 +129,16 @@ Create environment from HuggingFace Hub (MAIA pattern).
   - configuration_file: Override config path
   - run_root: Output directory (default: &#x27;runs&#x27;)
   - run_name: Run name (auto-generate if None)
-  - reward_agg: &#x27;mean&#x27; or &#x27;sum&#x27; (default: &#x27;mean&#x27;)
-  - normalize_input: Override normalization strategy
-  - nb_interactions: Override episode length
-  - random_init: Override IC randomization
-  - rescale_actions: Override action rescaling
-  - rew_mode: Override reward mode
+  - reward_agg: &#x27;mean&#x27;, &#x27;sum&#x27;, or &#x27;median&#x27; (default: &#x27;mean&#x27;); legacy name
+  - reward_aggregation: same as reward_agg, primary name (takes precedence)
+  - normalize_input: Override normalization strategy (shorthand)
+  - nb_interactions: Override episode length (shorthand)
+  - random_init: Override IC randomization (shorthand)
+  - rescale_actions: Override action rescaling (shorthand)
+  - rew_mode: Override reward mode (shorthand)
+  - &#x27;&lt;section&gt;.&lt;param&gt;&#x27;: Override ANY existing config-tree entry by
+  dotted path (e.g. &#x27;simulation.walltime&#x27;); unknown paths raise
+  ConfigError
   
 
 **Returns**:
@@ -142,10 +148,10 @@ Create environment from HuggingFace Hub (MAIA pattern).
 
 **Example**:
 
-  env = NekEnv.from_hf(&#x27;MiniChannel_Re180&#x27;, nproc=10)
+  env = NekEnv.from_hf(&#x27;TCFmini_3D_Re180&#x27;, nproc=10)
   
   env = NekEnv.from_hf(
-  &#x27;MiniChannel_Re180&#x27;,
+  &#x27;TCFmini_3D_Re180&#x27;,
   nproc=10,
   hostfile=&#x27;hosts.txt&#x27;,
   use_clean_cache=True,
@@ -177,8 +183,10 @@ Step the environment.
 
 - `observation` - Flat array of observations, shape (n_actuators * obs_per_actuator,)
 - `reward` - Scalar reward
-- `terminated` - Whether episode is done
-- `truncated` - Whether episode was truncated (always False for Nek)
+- `terminated` - Always False for Nek (physics failure raises
+  NekDivergenceError from _evolve instead)
+- `truncated` - Whether the episode budget was reached (simulation
+  end time tmax or nb_interactions RL steps)
 - `info` - Additional information
 
 #### render
@@ -204,6 +212,20 @@ class RingBuffer()
 ```
 
 N-dimensional ring buffer using numpy arrays.
+
+#### \_\_init\_\_
+
+```python
+def __init__(length, dim=1)
+```
+
+Allocate the backing array.
+
+**Arguments**:
+
+- `length` - Number of entries the buffer holds before wrapping.
+- `dim` - Shape of each entry (an int, or a tuple of axis sizes);
+  defaults to scalar entries.
 
 #### extend
 

--- a/docs/docs/api/nek/integrate.md
+++ b/docs/docs/api/nek/integrate.md
@@ -7,30 +7,50 @@ title: hydrogym.nek.integrate
 
 ```python
 def integrate(env,
-              t_span: Tuple[float, float],
+              t_span: Optional[Tuple[float, float]] = None,
               dt: Optional[float] = None,
               callbacks: Iterable[CallbackBase] = [],
               controller: Optional[Callable] = None,
-              max_steps: Optional[int] = None)
+              max_steps: Optional[int] = None,
+              num_steps: Optional[int] = None)
 ```
 
 Integrate a Nek environment through time.
 
+The loop runs until one of the following stops it first: the end of
+``t_span`` is reached, the step budget (``max_steps``/``num_steps``) is
+exhausted, or the environment reports the episode is over
+(``terminated or truncated``).
+
 **Arguments**:
 
 - `env` - Nek environment (NekEnv, NekParallelEnv, or NekPettingZooEnv)
-- `t_span` - Tuple of (start_time, end_time)
-- `dt` - Time step (optional, uses env&#x27;s default if not provided)
-- `callbacks` - List of callbacks to evaluate throughout the solve
-- `controller` - Controller object or function. Supports multiple formats:
-  - SB3-style object: Object with `predict()` method (e.g.,
-  `model.predict(obs, state=..., episode_start=..., deterministic=True)`)
-  - Legacy function: `action = controller(t, obs, env)` or
-  `action = controller(t, obs)`
-- `max_steps` - Maximum number of steps (optional)
+- `t_span` - Tuple of (start_time, end_time). Optional: when omitted the
+  loop is bounded only by the step budget (and episode termination),
+  and simulated time is reported relative to t=0.
+- ``0 - Time step (optional, uses env&#x27;s default if not provided)
+- ``1 - List of callbacks to evaluate throughout the solve
+- ``2 - Controller object or function. Supports multiple formats:
+  - SB3-style object: Object with ``3 method (e.g.,
+  ``4)
+  - Legacy function: ``5 or
+  ``6
+- ``7 - Maximum number of steps (optional). If not given, derived
+  from t_span (number of dt intervals + 1).
+- ``8 - Alternative step bound, taking precedence over max_steps
+  when both are given. Provided for callers that think in interaction
+  counts rather than a time span (e.g.
+  ``integrate(env, controller=model, num_steps=1000)``); it is the
+  same kind of limit as max_steps, not an additional one.
   
 
 **Returns**:
 
   The environment after integration
+  
+
+**Raises**:
+
+- ``1 - if no stop condition is specified (neither t_span nor a
+  step budget via max_steps/num_steps).
 

--- a/docs/docs/api/registration.md
+++ b/docs/docs/api/registration.md
@@ -1,0 +1,52 @@
+---
+sidebar_label: registration
+title: hydrogym.registration
+---
+
+gymnasium registration for HydroGym environments (audit Task 6.1).
+
+Importing this module registers a canonical set of environment IDs so
+`gym.make(...)` works uniformly across the gymnasium-API backends.
+
+gymnasium requires IDs of the form `[namespace/]name-vN` (one namespace
+segment), so each backend gets its own namespace: `hydrogym` (Firedrake,
+the historical IDs), `hydrogym-maia`, `hydrogym-nek`, `hydrogym-jaxfluids`.
+
+**Examples**:
+
+  &gt;&gt;&gt; import hydrogym.registration  # registers the IDs below (once)
+  &gt;&gt;&gt; import gymnasium as gym
+  &gt;&gt;&gt; env = gym.make(&#x27;hydrogym/Cylinder-v0&#x27;)
+  &gt;&gt;&gt; env = gym.make(&#x27;hydrogym-maia/Cylinder_2D_Re200-v0&#x27;, nproc=4)
+  &gt;&gt;&gt; env = gym.make(&#x27;hydrogym-nek/TCFmini_3D_Re180-v0&#x27;, nproc=10)
+  &gt;&gt;&gt; env = gym.make(&#x27;hydrogym-jaxfluids/Nozzle2D-v0&#x27;, env_config=`{}`)
+  
+  Design notes (following the audit&#x27;s Solver Interface Design):
+  - Registration is deliberately lazy: every entry point imports its backend
+  only when the environment is actually constructed, so
+  `import hydrogym.registration` never pays for mpi4py / jax / jaxfluids
+  imports and never initializes MPI.
+  - Backend-native config schemas are preserved: `gym.make` passes its
+  keyword arguments straight through to each backend&#x27;s own factory
+  (`from_hf` for MAIA/Nek, `env_config` dicts for Firedrake and
+  JAX-Fluids).
+  - The JAX backend is intentionally NOT registered: it implements the
+  functional/gymnax contract (`[namespace/]name-vN`0), whose
+  `[namespace/]name-vN`1/`[namespace/]name-vN`2 signatures differ from `[namespace/]name-vN`3. Wrapping it
+  in `gym.make` would present a misleading API; use
+  `[namespace/]name-vN`5 directly (see docs/docs/developers/adding-a-solver.md,
+  Pattern 3).
+  - The MAIA/NEK/JAX-Fluids IDs below are representative entry points, not an
+  exhaustive catalog: the HF Hub hosts many more environments per backend,
+  and each backend&#x27;s own `from_hf` accepts any registered environment
+  name (see docs/docs/developers/adding-an-environment.md).
+
+#### register\_all
+
+```python
+def register_all() -> None
+```
+
+Register every built-in environment ID. Idempotent; called on module
+import. New IDs should follow the same lazy-factory pattern.
+

--- a/docs/docs/api/sidebars-api.json
+++ b/docs/docs/api/sidebars-api.json
@@ -38,7 +38,10 @@
         },
         {
           "items": [
-            "api/firedrake/solvers/base"
+            "api/firedrake/solvers/base",
+            "api/firedrake/solvers/bdf_ext",
+            "api/firedrake/solvers/integrate",
+            "api/firedrake/solvers/stabilization"
           ],
           "label": "hydrogym.firedrake.solvers",
           "type": "category"
@@ -87,7 +90,7 @@
           "type": "category"
         },
         "api/jax/env_core",
-        "api/jax/flow"
+        "api/jax/equation"
       ],
       "label": "hydrogym.jax",
       "type": "category"
@@ -131,7 +134,6 @@
           "type": "category"
         },
         "api/maia/env_core",
-        "api/maia/hf_data_manager",
         "api/maia/mpmd_interface",
         "api/maia/workspace"
       ],
@@ -170,7 +172,10 @@
     },
     "api/__init__",
     "api/core",
-    "api/data_manager"
+    "api/core_external",
+    "api/data_manager",
+    "api/hf_env_mixin",
+    "api/registration"
   ],
   "label": "hydrogym",
   "type": "category"

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 HydroGym is a reinforcement learning platform for active flow control in fluid dynamics. It provides a unified, [Gymnasium](https://gymnasium.farama.org/)-compatible interface to 89 pre-configured CFD environments that span six solver backends, two to three spatial dimensions, and Reynolds numbers from laminar benchmarks to wall-bounded turbulence above Re = 400 000.
 
-The central design goal is to make it straightforward to apply standard RL tooling and techniques — [Stable-Baselines3](https://stable-baselines3.readthedocs.io/), [TorchRL](https://github.com/pytorch/rl), [RLlib](https://docs.ray.io/en/latest/rllib/index.html), [PettingZoo](https://pettingzoo.farama.org/), or your own training loop — to a broad set of physically meaningful flow control problems without having to write a custom environment or solver interface. Every environment exposes the same `env.reset()` / `env.step()` API; solver-specific setup is handled behind the scenes.
+The central design goal is to make it straightforward to apply standard RL tooling and techniques — [Stable-Baselines3](https://stable-baselines3.readthedocs.io/), [TorchRL](https://github.com/pytorch/rl), [RLlib](https://docs.ray.io/en/latest/rllib/index.html), [PettingZoo](https://pettingzoo.farama.org/), or your own training loop — to a broad set of physically meaningful flow control problems without having to write a custom environment or solver interface. Every environment exposes the same `env.reset()` / `env.step()` API, started the same way via gymnasium's `gym.make()` (see the [Quickstart](./quickstart)); solver-specific setup — including MPMD coupling for MAIA/NEK5000 — is handled behind the scenes. JAX is the one backend with a different, functional API by design; see the Quickstart for why.
 
 Environment configurations and initial-condition checkpoints are distributed through [HuggingFace Hub](https://huggingface.co/datasets/dynamicslab/HydroGym-environments) as a dedicated dataset and are downloaded automatically the first time an environment is created. Pre-built Docker images are available for all solver backends, making it possible to go from zero to a running training loop in a single `docker pull` command.
 
@@ -18,10 +18,10 @@ The six presently supported solver backends are:
 |---------|--------|:---:|---|
 | [Firedrake](./installation/firedrake) | Finite element (FEM) | 20 | 2-D |
 | [MAIA LBM](./installation/maia) | Lattice Boltzmann | 55 | 2-D, 3-D |
-| [MAIA Structured FV](./installation/maia) | Finite volume | 8 | 3-D |
-| [NEK5000](./installation/nek5000) | Spectral element (SEM) | 1 | 3-D |
+| [MAIA Structured FV](./installation/maia) | Finite volume | 4 | 3-D |
+| [NEK5000](./installation/nek5000) | Spectral element (SEM) | 4 | 3-D |
 | [JAX](./installation/jax) | Spectral / finite-difference, fully differentiable | 2 | 2-D, 3-D |
-| [JAX-Fluids](./installation/jaxfluids) | Compressible finite volume, fully differentiable | 2 | 2-D, 3-D |
+| [JAX-Fluids](./installation/jaxfluids) | Compressible finite volume, fully differentiable | 4 | 2-D, 3-D |
 
 To get a solver running immediately, proceed to the [Quickstart](./quickstart).
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -72,7 +72,33 @@ the environment configurations currently published on the
 | **JAX** `SEM, FD` | 2 | Differentiable fluid dynamics | 2D, 3D |
 | **JAX-Fluids** `FVM` | 4 | Compressible jet engine control | 2D, 3D |
 
-HydroGym interfaces with [Hugging Face](https://huggingface.co/datasets/dynamicslab/HydroGym-environments) to easily set up fluid environments. Hugging Face currently contains several pre-configured environments that can be loaded via `.from_hf()`. For instance, MAIA environments can be loaded as follows:
+### The standard entry point: `gym.make()`
+
+The recommended way to start any environment is gymnasium's `gym.make()`
+— one call, the same shape regardless of backend:
+
+```python
+import gymnasium as gym
+import hydrogym.registration
+
+env = gym.make("hydrogym/Cylinder-v0")           # Firedrake
+env = gym.make("hydrogym-maia/Cylinder_2D_Re200-v0")  # MAIA (real MPMD underneath)
+env = gym.make("hydrogym-nek/TCFmini_3D_Re180-v0", nproc=10)  # Nek5000 (real MPMD underneath)
+env = gym.make("hydrogym-jaxfluids/Nozzle2D-v0")  # JAX-Fluids
+
+obs, info = env.reset()
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+```
+
+MAIA and Nek5000 must still be launched as MPMD jobs (`mpirun -np 1
+python script.py : -np N maia/nek5000 ...`) — `gym.make()` constructs and
+wires up the coupling once inside that job, it does not remove the need
+for it. JAX is the one backend not reachable through `gym.make()`: it
+implements a functional/JIT (`gymnax`-style) contract for
+`jax.jit`/`jax.vmap`/`jax.lax.scan` compatibility, incompatible with
+`gymnasium.Env`'s `self`-mutating shape — see `examples/jax/`.
+
+HydroGym interfaces with [Hugging Face](https://huggingface.co/datasets/dynamicslab/HydroGym-environments) to easily set up fluid environments; `gym.make()` resolves environment data from there automatically. Every backend's lower-level, native construction path (used internally by `gym.make()`, and fully supported directly) also remains available — for instance, MAIA environments can be loaded via `.from_hf()`:
 
 ```python
 import hydrogym.maia as maia

--- a/examples/firedrake/README.md
+++ b/examples/firedrake/README.md
@@ -9,7 +9,8 @@ firedrake/
 ├── README.md                        # This file
 ├── getting_started/                 # START HERE - Standard RL interface
 │   ├── README.md                    # Complete getting started guide
-│   ├── test_firedrake_env.py        # Interactive test script
+│   ├── gym_make_demo.py             # gym.make() -- the standard entry point
+│   ├── test_firedrake_env.py        # Interactive test script (lower-level, direct FlowEnv)
 │   ├── config_reference.py          # Copy-paste configuration examples
 │   └── run_example_docker.sh        # Docker runner script
 └── advanced/                        # Advanced workflows (not standard RL)
@@ -47,16 +48,29 @@ firedrake/
 
 ## Quick Start
 
-### **New Users: Start with the RL Interface**
+### **New Users: Start with `gym.make()`**
 
-If you want to use HydroGym for **reinforcement learning** (the standard use case):
+The standard, recommended entry point for RL use is gymnasium's `gym.make()`:
 
 ```bash
 cd getting_started
-python test_firedrake_env.py --environment cylinder --num-steps 10
+python gym_make_demo.py --env hydrogym/Cylinder-v0 --steps 10
 ```
 
-This demonstrates the standard `env.reset()` / `env.step()` interface.
+```python
+import gymnasium as gym
+import hydrogym.registration
+
+env = gym.make("hydrogym/Cylinder-v0")
+obs, info = env.reset()
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+```
+
+`test_firedrake_env.py` demonstrates the same `env.reset()` / `env.step()`
+interface via the lower-level, direct `FlowEnv` construction path (see
+"Lower-level entry points" below) -- useful when you need something
+`gym.make()`'s registered defaults don't cover, but `gym.make()` is the
+right place to start.
 
 **Next steps:**
 1. Read [getting_started/README.md](getting_started/README.md) for complete documentation
@@ -81,11 +95,27 @@ python run-transient.py
 **Purpose:** Train reinforcement learning agents
 
 **Key files:**
-- `test_firedrake_env.py` - Interactive testing with standard Gym API
+- `gym_make_demo.py` - the standard entry point, `gym.make()`
+- `test_firedrake_env.py` - Interactive testing via the lower-level, direct `FlowEnv` path
 - `config_reference.py` - 10 copy-paste configuration examples
 - Full documentation in [getting_started/README.md](getting_started/README.md)
 
-**Typical usage:**
+**Typical usage (standard entry point):**
+```python
+import gymnasium as gym
+import hydrogym.registration
+
+env = gym.make("hydrogym/Cylinder-v0", env_config={"flow_config": {"mesh": "medium", "Re": 100}})
+obs, info = env.reset()
+
+for _ in range(100):
+    action = env.action_space.sample()
+    obs, reward, terminated, truncated, info = env.step(action)
+```
+
+**Lower-level entry point** (direct `FlowEnv` construction -- same result,
+useful for custom flow/solver classes `gym.make()`'s registry doesn't
+know about):
 ```python
 from hydrogym import FlowEnv
 import hydrogym.firedrake as hgym

--- a/examples/firedrake/advanced/README.md
+++ b/examples/firedrake/advanced/README.md
@@ -25,20 +25,20 @@ These examples are intended for:
 ## Example Types
 
 ### Steady-State Solvers (`solve-steady.py`)
-Find equilibrium solutions using Newton iteration:
+Find equilibrium solutions using Newton iteration (see `cylinder/solve-steady.py`
+for the full, runnable version with Reynolds-number ramping and output saving):
 ```python
-from hydrogym.firedrake import Cylinder, IPCS
-from hydrogym.firedrake.utils import solve_steady_state_stokes
+import hydrogym.firedrake as hgym
 
-flow = Cylinder(Re=100, mesh='medium')
-solver_parameters = {"snes_monitor": None}
+flow = hgym.Cylinder(Re=100, mesh="medium", use_HF_data_manager=False)
 solver = hgym.NewtonSolver(
     flow,
-    stabilization="gls",  
-    solver_parameters=solver_parameters,
+    stabilization="gls",
+    solver_parameters={"snes_monitor": None},
 )
 
-solver.solve()
+qB = solver.solve()
+CL, CD = flow.compute_forces()
 ```
 
 ### Direct Control (`pd-control.py`)

--- a/examples/jax/README.md
+++ b/examples/jax/README.md
@@ -12,6 +12,17 @@ HydroGym's JAX backend provides pseudo-spectral Navier-Stokes solvers written en
 
 The JAX environments follow the [gymnax](https://github.com/RobertTLange/gymnax) interface (`reset_env` / `step_env` with explicit `params`) and include wrappers (`VecEnv`, `LogWrapper`, `ClipAction`, `NormalizeVecObservation`, `NormalizeVecReward`) for RL training.
 
+> **Note on `gym.make()`:** every other HydroGym backend (Firedrake, MAIA,
+> NEK5000, JAX-Fluids) is reachable through gymnasium's `gym.make()`, the
+> standard, recommended entry point across the rest of this repo. JAX is
+> the one deliberate exception: `reset_env`/`step_env` are functional
+> (state in, state out) so the whole thing stays traceable through
+> `jax.jit`/`jax.vmap`/`jax.lax.scan` — a `self`-mutating `gymnasium.Env`
+> cannot be, so wrapping it in `gym.make()` would present a misleading
+> API rather than a real one. The functional API below (or
+> `hydrogym.jax.envs.*` directly) is always the entry point for this
+> backend; there is no higher-level wrapper to bypass.
+
 ## Directory Structure
 
 ```

--- a/examples/jaxfluids/README.md
+++ b/examples/jaxfluids/README.md
@@ -1,0 +1,56 @@
+# JAX-Fluids Examples
+
+Examples demonstrating HydroGym's JAX-Fluids backend for compressible,
+fully-differentiable flow control (nozzle shock-vector control).
+
+## Standard entry point: `gym.make()`
+
+```bash
+python gym_make_demo.py
+python gym_make_demo.py --env hydrogym-jaxfluids/Nozzle3D-v0 --steps 2
+```
+
+```python
+import gymnasium as gym
+import hydrogym.registration
+
+env = gym.make("hydrogym-jaxfluids/Nozzle2D-v0")  # defaults to the "_coarse" resolution
+obs, info = env.reset()
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+```
+
+There is no plain `"Nozzle2D"`/`"Nozzle3D"` environment on the Hugging
+Face Hub — only resolution-suffixed variants
+(`Nozzle2D_coarse`/`_fine`, `Nozzle3D_coarse`/`_fine`). `gym.make()`
+defaults both registered ids to `_coarse`; pass a specific one via
+`env_config={"environment_name": "Nozzle2D_fine"}`.
+
+## Lower-level entry point
+
+For direct construction (custom `environment_config.yaml`, or anything
+`gym.make()`'s registered default doesn't cover), see `test_jaxfluids_env.py`:
+
+```python
+from hydrogym.jaxfluids.envs import Nozzle2D
+
+env = Nozzle2D(env_config={"environment_name": "Nozzle2D_coarse"})
+obs, info = env.reset()
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+```
+
+## Files
+
+- `gym_make_demo.py` — the standard entry point, `gym.make()`
+- `test_jaxfluids_env.py` — interactive test via the lower-level, direct construction path
+- `environment_config.yaml` — example config reference
+
+## Notes
+
+- Requires internet access on first run to download environment data from
+  the Hugging Face Hub (`dynamicslab/HydroGym-environments`).
+- JAX-Fluids' `step()`/`reset()` return values come from the wrapped
+  external `jaxfluids_rl.JAXFluidsEnv` package; gymnasium's passive env
+  checker may warn about `float64` vs. the declared `float32` observation
+  dtype and about `terminated`/`truncated` being JAX array scalars rather
+  than plain Python `bool` — informational only, not fatal, and does not
+  affect correctness of `obs`/`reward` values.

--- a/examples/maia/README.md
+++ b/examples/maia/README.md
@@ -12,7 +12,8 @@ MAIA is a high-performance CFD solver designed for massively parallel simulation
 maia/
 ├── README.md              # This file
 └── getting_started/       # START HERE - Standard RL interface
-    ├── test_maia_env.py   # Interactive test script with MPMD
+    ├── gym_make_demo.py   # gym.make() -- the standard entry point (MPMD underneath)
+    ├── test_maia_env.py   # Interactive test script (lower-level, direct from_hf)
     ├── prepare_workspace.py  # Workspace setup utility
     └── run_example_docker.sh # HPC job runner script (loads env modules; not Docker despite the name)
 ```
@@ -29,6 +30,11 @@ maia/
 
 ### Running Your First Example
 
+MAIA is still reached through the standard `gym.make()` entry point --
+the only difference from Firedrake/JAX-Fluids is that it must be launched
+as an MPMD job, since the real solver runs as a separate MPI application
+that Python talks to over MPI, not a library call:
+
 ```bash
 cd getting_started
 
@@ -37,8 +43,25 @@ python prepare_workspace.py --env Cylinder_2D_Re200 --work-dir ./test_run
 
 # Step 2: Run with MPMD execution (1 Python process + 1 MAIA process)
 cd test_run
-mpirun -np 1 python ../test_maia_env.py --environment Cylinder_2D_Re200 : -np 1 maia properties_run.toml
+mpirun -np 1 python ../gym_make_demo.py : -np 1 maia properties_run.toml
 ```
+
+```python
+# gym_make_demo.py's core, once inside the MPMD-launched process:
+import gymnasium as gym
+import hydrogym.registration
+
+env = gym.make("hydrogym-maia/Cylinder_2D_Re200-v0")  # verified default probe grid, zero extra args
+obs, info = env.reset()
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+```
+
+Other MAIA ids (e.g. `hydrogym-maia/RotaryCylinder_2D_Re1000-v0`) have no
+universal default probe grid and need `probe_locations=[...]` passed to
+`gym.make()` explicitly -- it raises a clear error naming this if it's
+missing, rather than guessing at a flow-geometry-specific default. See
+`test_maia_env.py` for the lower-level `hydrogym.maia.from_hf(...)` path
+and worked probe-grid examples.
 
 **Note:** MAIA uses MPMD (Multiple Program Multiple Data) execution where Python and MAIA run as separate MPI programs that communicate.
 

--- a/examples/nek/getting_started/3_pettingzoo/train_sb3_pettingzoo.py
+++ b/examples/nek/getting_started/3_pettingzoo/train_sb3_pettingzoo.py
@@ -55,7 +55,6 @@ def train_pettingzoo_with_supersuit(args):
 
     # Convert to SB3-compatible format using SuperSuit
     try:
-        from pettingzoo.utils import parallel_to_aec
         from supersuit import black_death_v3, pad_action_space_v0, pad_observations_v0
     except ImportError:
         print("✗ Error: PettingZoo/SuperSuit not installed!")

--- a/examples/nek/getting_started/README.md
+++ b/examples/nek/getting_started/README.md
@@ -6,6 +6,32 @@ This directory contains comprehensive examples for using HydroGym's NEK5000-base
 
 > **Note:** NEK5000 requires MPI for parallel execution. All examples use `mpirun` to coordinate between the Python controller and NEK5000 solver processes.
 
+## Standard entry point: `gym.make()`
+
+For the common single-agent case, the standard, recommended way to start
+a Nek5000 environment is gymnasium's `gym.make()` — same call shape as
+every other backend, MPMD coupling handled underneath:
+
+```bash
+# from a prepared workspace (see prepare_workspace.py)
+mpirun -np 1 python gym_make_demo.py --nproc 10 : -np 10 nek5000
+```
+
+```python
+import gymnasium as gym
+import hydrogym.registration
+
+env = gym.make("hydrogym-nek/TCFmini_3D_Re180-v0", nproc=10)  # nproc required, must match the MPMD launch
+obs, info = env.reset()
+obs, reward, terminated, truncated, info = env.step(env.action_space.sample())
+```
+
+See `gym_make_demo.py` in this directory. The 6 patterns below (multi-agent
+wrappers, `from_hf`, `integrate()`, zero-shot deployment) are the
+lower-level entry points for everything `gym.make()`'s single-agent
+default doesn't cover — construct `NekEnv` directly, same as `gym.make()`
+does underneath.
+
 ## Directory Structure
 
 Each subdirectory demonstrates a specific interface pattern with complete examples:
@@ -47,16 +73,17 @@ model.learn(total_timesteps=100000)
 **SB3 Compatible:** ⚠️ Requires wrapper (SuperSuit or custom)
 
 ```python
-from hydrogym.nek import parallel_env
+from hydrogym.nek import NekEnv
+from hydrogym.nek.parallel_env import NekParallelEnv
 
-env = parallel_env(
-    environment_name='TCFmini_3D_Re180',
-    nproc=10,
-    num_agents=3,  # Multiple agents
-)
+# NekParallelEnv wraps an already-constructed NekEnv (composition, not a
+# factory taking environment_name/nproc directly) -- one agent per actuator,
+# discovered automatically from the base env's actuator info.
+base_env = NekEnv(env_config={"environment_name": "TCFmini_3D_Re180", "nproc": 10})
+env = NekParallelEnv(base_env)
 
 # Dictionary-based observations and actions
-obs = env.reset()  # {'agent_0': array, 'agent_1': array, 'agent_2': array}
+obs, info = env.reset()  # {'jet_np...': array, ...}, one key per actuator agent
 actions = {agent: env.action_space(agent).sample() for agent in env.agents}
 obs, rewards, terminations, truncations, infos = env.step(actions)
 ```
@@ -68,30 +95,32 @@ obs, rewards, terminations, truncations, infos = env.step(actions)
 
 ---
 
-### 3. [`3_pettingzoo/`](3_pettingzoo/) - PettingZoo AEC Interface
-**Interface:** PettingZoo AEC (Agent Environment Cycle)
-**Use Case:** Turn-based multi-agent scenarios
-**Configuration File:**: An example of using configuration to replicate training. 
+### 3. [`3_pettingzoo/`](3_pettingzoo/) - PettingZoo-Spec-Compliant Parallel API
+**Interface:** `pettingzoo.ParallelEnv` subclass wrapping `NekParallelEnv`
+**Use Case:** Same simultaneous, dict-based multi-agent interaction as
+`2_parallel_env/` above, but as a genuine `pettingzoo.ParallelEnv`
+subclass (PettingZoo `metadata`, cached `observation_space`/`action_space`)
+for interop with PettingZoo-ecosystem tools that type-check for it.
+**Not** the turn-based AEC (`agent_iter()`/`last()`) interface — Nek5000
+has no AEC wrapper; every agent acts every step, same as `2_parallel_env/`.
 **SB3 Compatible:** ⚠️ Requires wrapper
 
 ```python
-from hydrogym.nek import parallel_env
-from pettingzoo.utils import parallel_to_aec
+from hydrogym.nek import NekEnv
+from hydrogym.nek.pettingzoo_env import make_pettingzoo_env
 
-parallel = parallel_env(environment_name='TCFmini_3D_Re180', nproc=10)
-env = parallel_to_aec(parallel)
+base_env = NekEnv(env_config={"environment_name": "TCFmini_3D_Re180", "nproc": 10})
+env = make_pettingzoo_env(base_env)
 
-# Turn-based API
-env.reset()
-for agent in env.agent_iter():
-    observation, reward, termination, truncation, info = env.last()
-    action = env.action_space(agent).sample()
-    env.step(action)
+# Same dict-based, simultaneous-action API as NekParallelEnv above
+obs, info = env.reset()
+actions = {agent: env.action_space(agent).sample() for agent in env.agents}
+obs, rewards, terminations, truncations, infos = env.step(actions)
 ```
 
 **Files:**
-- `test_nek_pettingzoo.py` - AEC interface test
-- `train_sb3_pettingzoo.py` - Training with turn-based agents
+- `test_nek_pettingzoo.py` - `pettingzoo.ParallelEnv`-compliance test
+- `train_sb3_pettingzoo.py` - Training with SuperSuit-wrapped parallel agents
 - `run_pettingzoo_docker.sh` - Docker/MPI execution script
 
 ---
@@ -204,7 +233,7 @@ mpirun -np 1 python train_sb3_nek_direct.py \
 |-----------|-----------|------------|---------------|------------|----------|
 | **1_nekenv_single** | `NekEnv` | Array | Array | ✅ Yes | Single actuator, simple baseline |
 | **2_parallel_env** | `parallel_env` | Dict | Dict | ⚠️ Wrapper | Independent multi-agent scenarios |
-| **3_pettingzoo** | AEC | Sequential | Sequential | ⚠️ Wrapper | Turn-based agents |
+| **3_pettingzoo** | `pettingzoo.ParallelEnv` | Dict | Dict | ⚠️ Wrapper | PettingZoo-ecosystem interop |
 | **4_from_hf** | Any | Depends | Depends | Depends | Reproducible, versioned environments |
 | **5_hydrogym_control** | Any + `integrate()` | Any | Any | ✅ Yes | Classical + RL hybrid control |
 | **6_zeroshot_wing_demo** | PettingZoo Parallel | Dict | Dict | ✅ Deployment | Small-wing zero-shot DRL rollout |

--- a/hydrogym/firedrake/solvers/bdf_ext.py
+++ b/hydrogym/firedrake/solvers/bdf_ext.py
@@ -52,7 +52,7 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
     def __init__(
         self,
         flow: FlowConfig,
-        dt: float,
+        dt: float = None,
         order: int = 3,
         stabilization: str = "default",
         rtol=1e-6,
@@ -63,7 +63,11 @@ class SemiImplicitBDF(NavierStokesTransientSolver):
 
         Args:
             flow: Flow configuration (mesh, mixed space, BCs, forcing).
-            dt: Timestep size.
+            dt: Timestep size. Optional; defaults to the flow's
+                ``DEFAULT_DT`` if not given (see
+                ``NavierStokesTransientSolver``/``TransientSolver``, whose
+                contract this class previously broke by requiring ``dt``
+                positionally).
             order: Order of the BDF/extrapolation scheme (1-3).
             stabilization: Stabilization type; ``"default"`` resolves to the
                 flow's ``DEFAULT_STABILIZATION``. See ``ns_stabilization`` for

--- a/hydrogym/jaxfluids/envs/__init__.py
+++ b/hydrogym/jaxfluids/envs/__init__.py
@@ -1,0 +1,3 @@
+from .nozzle import Nozzle2D, Nozzle3D
+
+__all__ = ["Nozzle2D", "Nozzle3D"]

--- a/hydrogym/maia/env_core.py
+++ b/hydrogym/maia/env_core.py
@@ -146,6 +146,15 @@ class MaiaFlowEnv(HFEnvConfigMixin, gym.Env):
         # Standard initialization
         self.is_testing = env_config.get("is_testing", False)
         self.probe_locations = env_config.get("probe_locations")
+        if self.probe_locations is None:
+            raise ConfigError(
+                "'probe_locations' must be specified in env_config -- there is no "
+                "universal default (the sensible probe grid is a per-flow-geometry "
+                "choice). Example for a 2D flow: probe_locations=[x0, y0, x1, y1, ...] "
+                "(flattened coordinate pairs); see MaiaFlowEnv's docstring / "
+                "examples/maia/getting_started/test_maia_env.py's create_probe_locations "
+                "for a worked example."
+            )
         self.obs_normalization_strategy = env_config.get("obs_normalization_strategy", "none")
 
         valid_strategies = ["U_inf", "probewise_mean_std", "none", "customized"]

--- a/hydrogym/registration.py
+++ b/hydrogym/registration.py
@@ -54,15 +54,44 @@ _FIREDRAKE_ENVS = {
 }
 
 # Representative MAIA environment names (verified in the from_hf docstring).
-_MAIA_ENVS = ["Cylinder_2D_Re200", "RotaryCylinder_2D_Re1000", "Cavity_2D_Re4140"]  # ns: hydrogym-maia
+# `probe_locations` has no universal default (the sensible probe grid is a
+# per-flow-geometry choice -- MaiaFlowEnv raises a clear ConfigError if it's
+# omitted, see env_core.py), so only environments with a verified-working
+# default grid get one supplied here; the others require the caller to pass
+# `probe_locations=` explicitly, same shape of requirement as Nek's `nproc`.
+# Cylinder_2D_Re200's default is the wake-sampling grid from
+# examples/maia/getting_started/test_maia_env.py's create_probe_locations
+# (8 downstream x 5 crossflow, x in [1, 8], y in [-1, 1]) -- run repeatedly
+# against the real solver with this exact grid, real sensible reward output.
+_MAIA_ENVS = {
+    "Cylinder_2D_Re200": {
+        "probe_locations": [
+            coord
+            for x in [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+            for y in [-1.0, -0.5, 0.0, 0.5, 1.0]
+            for coord in (x, y)
+        ],
+        "obs_normalization_strategy": "U_inf",
+    },
+    "RotaryCylinder_2D_Re1000": {},
+    "Cavity_2D_Re4140": {},
+}  # ns: hydrogym-maia
 
 # Representative NEK environment (the documented smoke-test case; nproc must
 # match the MPMD launch, so it is a required make() kwarg here).
 _NEK_ENVS = ["TCFmini_3D_Re180"]  # ns: hydrogym-nek
 
 # Representative JAX-Fluids environments (constructed from an env_config
-# dict, as in examples/jaxfluids/).
-_JAXFLUIDS_ENVS = {"Nozzle2D": "Nozzle2D", "Nozzle3D": "Nozzle3D"}  # ns: hydrogym-jaxfluids
+# dict, as in examples/jaxfluids/). Maps gym ID suffix -> (env_class_name,
+# default HF environment_name). There is no plain "Nozzle2D"/"Nozzle3D" HF
+# environment -- only resolution-suffixed variants (confirmed via
+# HfApi().list_repo_files: Nozzle2D_coarse/_fine, Nozzle3D_coarse/_fine) --
+# so the gym ID's default must be one specific published environment;
+# "_coarse" matches examples/jaxfluids/test_jaxfluids_env.py's own default.
+_JAXFLUIDS_ENVS = {
+    "Nozzle2D": ("Nozzle2D", "Nozzle2D_coarse"),
+    "Nozzle3D": ("Nozzle3D", "Nozzle3D_coarse"),
+}  # ns: hydrogym-jaxfluids
 
 
 def _firedrake_make(flow_name: str):
@@ -80,11 +109,23 @@ def _firedrake_make(flow_name: str):
     return _make
 
 
-def _maia_make(environment_name: str):
+def _maia_make(environment_name: str, defaults: dict):
     def _make(**kwargs):
-        from hydrogym.maia.env_core import from_hf
+        # Import via the package (attribute access), not
+        # `from hydrogym.maia.env_core import from_hf`: hydrogym.maia lazily
+        # populates its MPI-dependent names -- including the env-class
+        # registration side effect of importing hydrogym.maia.envs.* -- only
+        # through its own __getattr__, which a direct submodule import
+        # bypasses entirely. Importing env_core directly leaves
+        # _ENVIRONMENT_REGISTRY empty, so from_hf() can't recognize any
+        # environment type ("Cylinder", "Pinball", ...) even though the
+        # class exists -- confirmed live: raises immediately outside MPMD,
+        # or strands the paired MAIA rank waiting forever for a handshake
+        # the crashed Python side never sends, inside MPMD.
+        import hydrogym.maia as maia
 
-        return from_hf(environment_name, **kwargs)
+        merged = {**defaults, **kwargs}
+        return maia.from_hf(environment_name, **merged)
 
     return _make
 
@@ -103,12 +144,14 @@ def _nek_make(environment_name: str):
     return _make
 
 
-def _jaxfluids_make(env_class_name: str):
+def _jaxfluids_make(env_class_name: str, default_environment_name: str):
     def _make(env_config: dict = None, **kwargs):
         from hydrogym.jaxfluids import envs as jxf_envs
 
         env_cls = getattr(jxf_envs, env_class_name)
-        return env_cls(env_config={**(env_config or {}), **kwargs})
+        merged = {**(env_config or {}), **kwargs}
+        merged.setdefault("environment_name", default_environment_name)
+        return env_cls(env_config=merged)
 
     return _make
 
@@ -123,14 +166,17 @@ def register_all() -> None:
     for env_id, flow_name in _FIREDRAKE_ENVS.items():
         gym.register(id=env_id, entry_point=_firedrake_make(flow_name))
 
-    for env_name in _MAIA_ENVS:
-        gym.register(id=f"hydrogym-maia/{env_name}-v0", entry_point=_maia_make(env_name))
+    for env_name, defaults in _MAIA_ENVS.items():
+        gym.register(id=f"hydrogym-maia/{env_name}-v0", entry_point=_maia_make(env_name, defaults))
 
     for env_name in _NEK_ENVS:
         gym.register(id=f"hydrogym-nek/{env_name}-v0", entry_point=_nek_make(env_name))
 
-    for env_name, env_class_name in _JAXFLUIDS_ENVS.items():
-        gym.register(id=f"hydrogym-jaxfluids/{env_name}-v0", entry_point=_jaxfluids_make(env_class_name))
+    for env_name, (env_class_name, default_environment_name) in _JAXFLUIDS_ENVS.items():
+        gym.register(
+            id=f"hydrogym-jaxfluids/{env_name}-v0",
+            entry_point=_jaxfluids_make(env_class_name, default_environment_name),
+        )
 
     _REGISTERED = True
 

--- a/hydrogym/registration.py
+++ b/hydrogym/registration.py
@@ -1,39 +1,38 @@
 """gymnasium registration for HydroGym environments (audit Task 6.1).
 
 Importing this module registers a canonical set of environment IDs so
-``gym.make(...)`` works uniformly across the gymnasium-API backends:
+`gym.make(...)` works uniformly across the gymnasium-API backends.
 
-    import hydrogym.registration  # registers the IDs below (once)
-    import gymnasium as gym
+gymnasium requires IDs of the form `[namespace/]name-vN` (one namespace
+segment), so each backend gets its own namespace: `hydrogym` (Firedrake,
+the historical IDs), `hydrogym-maia`, `hydrogym-nek`, `hydrogym-jaxfluids`.
 
-    env = gym.make("hydrogym/Cylinder-v0")
-    env = gym.make("hydrogym-maia/Cylinder_2D_Re200-v0", nproc=4)
-    env = gym.make("hydrogym-nek/TCFmini_3D_Re180-v0", nproc=10)
-    env = gym.make("hydrogym-jaxfluids/Nozzle2D-v0", env_config={...})
-
-gymnasium requires IDs of the form ``[namespace/]name-v<version>`` (one
-namespace segment), so each backend gets its own namespace: ``hydrogym``
-(Firedrake, the historical IDs), ``hydrogym-maia``, ``hydrogym-nek``,
-``hydrogym-jaxfluids``.
+Examples:
+    >>> import hydrogym.registration  # registers the IDs below (once)
+    >>> import gymnasium as gym
+    >>> env = gym.make('hydrogym/Cylinder-v0')
+    >>> env = gym.make('hydrogym-maia/Cylinder_2D_Re200-v0', nproc=4)
+    >>> env = gym.make('hydrogym-nek/TCFmini_3D_Re180-v0', nproc=10)
+    >>> env = gym.make('hydrogym-jaxfluids/Nozzle2D-v0', env_config={})
 
 Design notes (following the audit's Solver Interface Design):
 - Registration is deliberately lazy: every entry point imports its backend
   only when the environment is actually constructed, so
-  ``import hydrogym.registration`` never pays for mpi4py / jax / jaxfluids
+  `import hydrogym.registration` never pays for mpi4py / jax / jaxfluids
   imports and never initializes MPI.
-- Backend-native config schemas are preserved: ``gym.make`` passes its
+- Backend-native config schemas are preserved: `gym.make` passes its
   keyword arguments straight through to each backend's own factory
-  (``from_hf`` for MAIA/Nek, ``env_config`` dicts for Firedrake and
+  (`from_hf` for MAIA/Nek, `env_config` dicts for Firedrake and
   JAX-Fluids).
 - The JAX backend is intentionally NOT registered: it implements the
-  functional/gymnax contract (``gymnax.environment.Environment``), whose
-  ``reset``/``step`` signatures differ from ``gymnasium.Env``. Wrapping it
-  in ``gym.make`` would present a misleading API; use
-  ``hydrogym.jax.envs.*`` directly (see docs/docs/developers/adding-a-solver.md,
+  functional/gymnax contract (`gymnax.environment.Environment`), whose
+  `reset`/`step` signatures differ from `gymnasium.Env`. Wrapping it
+  in `gym.make` would present a misleading API; use
+  `hydrogym.jax.envs.*` directly (see docs/docs/developers/adding-a-solver.md,
   Pattern 3).
 - The MAIA/NEK/JAX-Fluids IDs below are representative entry points, not an
   exhaustive catalog: the HF Hub hosts many more environments per backend,
-  and each backend's own ``from_hf`` accepts any registered environment
+  and each backend's own `from_hf` accepts any registered environment
   name (see docs/docs/developers/adding-an-environment.md).
 """
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -13,7 +13,7 @@ def test_checkpointing(tmp_dir="tmp"):
         "flow_config": {
             "mesh": "coarse",  # Default mesh
         },
-        "solver": hgym.IPCS,
+        "solver": hgym.SemiImplicitBDF,
     }
     env = hgym.FlowEnv(env_config)
 
@@ -22,7 +22,7 @@ def test_checkpointing(tmp_dir="tmp"):
         env.step(1)
 
     env.flow.save_checkpoint(checkpoint_path)
-    omega = env.flow.actuators[0].value
+    omega = env.flow.actuators[0].state
 
     # new environment loading checkpoint
     env_config2 = {
@@ -31,17 +31,17 @@ def test_checkpointing(tmp_dir="tmp"):
             "mesh": "coarse",  # Default mesh
             "restart": checkpoint_path,
         },
-        "solver": hgym.IPCS,
+        "solver": hgym.SemiImplicitBDF,
     }
     env2 = hgym.FlowEnv(env_config2)
 
     # env2.reset()
-    omega2 = env2.flow.actuators[0].value
+    omega2 = env2.flow.actuators[0].state
     assert omega == omega2
 
     # Check that resetting still clears the actuator state
     env2.reset()
-    omega3 = env2.flow.actuators[0].value
+    omega3 = env2.flow.actuators[0].state
     assert omega3 == 0.0
 
 

--- a/test/test_jaxfluids_envs_package.py
+++ b/test/test_jaxfluids_envs_package.py
@@ -1,0 +1,23 @@
+"""Regression test: hydrogym.jaxfluids.envs must re-export its env classes.
+
+Found via `gym.make("hydrogym-jaxfluids/Nozzle2D-v0")` failing with
+`AttributeError: module 'hydrogym.jaxfluids.envs' has no attribute
+'Nozzle2D'` -- the package's __init__.py was empty, unlike every other
+backend's envs package (e.g. hydrogym.firedrake.envs re-exports Cylinder,
+Cavity, Pinball, Step, RotaryCylinder), so `getattr(jxf_envs,
+"Nozzle2D")` in hydrogym/registration.py's _jaxfluids_make had nothing to
+find even though `hydrogym.jaxfluids.envs.nozzle.Nozzle2D` existed all
+along.
+"""
+
+import pytest
+
+pytest.importorskip("jax")
+pytest.importorskip("jaxfluids")
+
+
+def test_nozzle_classes_are_reexported():
+    from hydrogym.jaxfluids import envs
+
+    assert hasattr(envs, "Nozzle2D")
+    assert hasattr(envs, "Nozzle3D")

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -182,18 +182,37 @@ def fake_maia(monkeypatch):
         captured["call"] = (name, kwargs)
         return _SentinelEnv(marker="MAIA_ENV_SENTINEL")
 
-    maia = _fake_module()
-    env_core = _fake_module(from_hf=fake_from_hf)
-    maia.env_core = env_core  # `from hydrogym.maia import env_core` needs the attr
+    # _maia_make imports `hydrogym.maia` as a package and calls
+    # `maia.from_hf(...)` (attribute access, not a submodule import) -- see
+    # its comment for why: importing hydrogym.maia.env_core directly
+    # bypasses the package's lazy __getattr__-triggered env-class
+    # registration and leaves _ENVIRONMENT_REGISTRY empty. The fake module
+    # must expose `from_hf` as its own attribute to match.
+    maia = _fake_module(from_hf=fake_from_hf)
     monkeypatch.setitem(sys.modules, "hydrogym.maia", maia)
-    monkeypatch.setitem(sys.modules, "hydrogym.maia.env_core", env_core)
     return captured
 
 
 def test_maia_factory_forwards_kwargs(fake_maia):
     env = gym.make("hydrogym-maia/Cylinder_2D_Re200-v0", disable_env_checker=True, nproc=4)
     assert env.unwrapped.marker == "MAIA_ENV_SENTINEL"
-    assert fake_maia["call"] == ("Cylinder_2D_Re200", {"nproc": 4})
+    name, kwargs = fake_maia["call"]
+    assert name == "Cylinder_2D_Re200"
+    assert kwargs["nproc"] == 4
+    # Cylinder_2D_Re200 ships a verified default probe grid (see
+    # registration.py's _MAIA_ENVS) so gym.make() works with no probe_locations.
+    assert "probe_locations" in kwargs
+
+
+def test_maia_factory_env_without_default_probes_requires_them(fake_maia):
+    # RotaryCylinder_2D_Re1000 / Cavity_2D_Re4140 have no verified default
+    # probe grid -- the caller must supply one (same shape of requirement as
+    # Nek's nproc). No defaults means an empty kwargs dict reaches from_hf,
+    # which is where the real (unmocked) MaiaFlowEnv raises ConfigError.
+    gym.make("hydrogym-maia/RotaryCylinder_2D_Re1000-v0", disable_env_checker=True)
+    name, kwargs = fake_maia["call"]
+    assert name == "RotaryCylinder_2D_Re1000"
+    assert "probe_locations" not in kwargs
 
 
 @pytest.fixture
@@ -249,4 +268,16 @@ def test_jaxfluids_factory_merges_env_config(fake_jaxfluids):
         env_config={"a": 1},
         b=2,
     )
-    assert fake_jaxfluids["call"] == {"a": 1, "b": 2}
+    # environment_name defaults to the registered HF environment (there is
+    # no plain "Nozzle2D" HF environment, only resolution-suffixed variants
+    # -- see registration.py's _JAXFLUIDS_ENVS comment) unless overridden.
+    assert fake_jaxfluids["call"] == {"a": 1, "b": 2, "environment_name": "Nozzle2D_coarse"}
+
+
+def test_jaxfluids_factory_caller_can_override_environment_name(fake_jaxfluids):
+    gym.make(
+        "hydrogym-jaxfluids/Nozzle2D-v0",
+        disable_env_checker=True,
+        env_config={"environment_name": "Nozzle2D_fine"},
+    )
+    assert fake_jaxfluids["call"]["environment_name"] == "Nozzle2D_fine"

--- a/test/test_registration.py
+++ b/test/test_registration.py
@@ -149,6 +149,21 @@ def fake_firedrake(monkeypatch):
     # execute the real (backend-heavy) parent/module chain here.
     monkeypatch.setitem(sys.modules, "hydrogym.firedrake", flow)
     monkeypatch.setitem(sys.modules, "hydrogym.core", core)
+    # _firedrake_make does `import hydrogym as hgym; ... hgym.firedrake`
+    # (attribute access on the *package*, not a submodule import) --
+    # hydrogym/__init__.py's lazy __getattr__ caches the real module into
+    # hydrogym.__dict__ the first time anything ever does
+    # `hydrogym.firedrake`, permanently, for the rest of the process. If any
+    # other collected test module (e.g. test_pinball.py) already triggered
+    # that real import before this fixture runs -- which pytest's collection
+    # phase does for every test file up front, regardless of which tests you
+    # actually select -- patching sys.modules alone is not enough: the cached
+    # attribute on the real `hydrogym` module object still wins over it.
+    # Patch that attribute directly too, so this fixture is correct
+    # regardless of what else got collected/imported first.
+    import hydrogym as _hydrogym_pkg
+
+    monkeypatch.setattr(_hydrogym_pkg, "firedrake", flow, raising=False)
     return captured
 
 
@@ -190,6 +205,19 @@ def fake_maia(monkeypatch):
     # must expose `from_hf` as its own attribute to match.
     maia = _fake_module(from_hf=fake_from_hf)
     monkeypatch.setitem(sys.modules, "hydrogym.maia", maia)
+    # `import hydrogym.maia as maia` resolves through attribute access on the
+    # real `hydrogym` package, not a fresh sys.modules lookup each call --
+    # confirmed empirically: two sequential gym.make() calls for two
+    # different MAIA ids, each with its own sys.modules swap, both ended up
+    # invoking the *first* call's fake (proven with a minimal repro outside
+    # pytest entirely, so this is not a monkeypatch/pytest artifact -- it's
+    # hydrogym/__init__.py's own lazy loader, which caches
+    # `globals()["maia"] = module` permanently the first time anything ever
+    # resolves `hydrogym.maia`, same mechanism already worked around for
+    # `fake_firedrake` above). Patch the attribute directly too.
+    import hydrogym as _hydrogym_pkg
+
+    monkeypatch.setattr(_hydrogym_pkg, "maia", maia, raising=False)
     return captured
 
 
@@ -230,6 +258,12 @@ def fake_nek(monkeypatch):
     nek.env = env
     monkeypatch.setitem(sys.modules, "hydrogym.nek", nek)
     monkeypatch.setitem(sys.modules, "hydrogym.nek.env", env)
+    # Same hydrogym.__init__ lazy-loader caching risk as fake_maia/
+    # fake_firedrake/fake_jaxfluids above ("nek" is also in the parent's
+    # lazy __getattr__ allowlist) -- defensive.
+    import hydrogym as _hydrogym_pkg
+
+    monkeypatch.setattr(_hydrogym_pkg, "nek", nek, raising=False)
     return captured
 
 
@@ -258,6 +292,14 @@ def fake_jaxfluids(monkeypatch):
     jxf = _fake_module(envs=envs)
     monkeypatch.setitem(sys.modules, "hydrogym.jaxfluids", jxf)
     monkeypatch.setitem(sys.modules, "hydrogym.jaxfluids.envs", envs)
+    # Same hydrogym.__init__ lazy-loader caching risk as fake_maia/
+    # fake_firedrake above -- defensive, not yet proven necessary for this
+    # fixture specifically, but the mechanism is identical (`hydrogym.
+    # jaxfluids` is also a lazy `_MPI_ATTRS`-style name in the parent's
+    # __getattr__), so patch it the same way rather than wait to hit it.
+    import hydrogym as _hydrogym_pkg
+
+    monkeypatch.setattr(_hydrogym_pkg, "jaxfluids", jxf, raising=False)
     return captured
 
 

--- a/test/test_semi_implicit_bdf_default_dt.py
+++ b/test/test_semi_implicit_bdf_default_dt.py
@@ -1,0 +1,35 @@
+"""Regression test: SemiImplicitBDF's dt must be optional.
+
+Found via `gym.make("hydrogym/Cylinder-v0")` (and every other registered
+Firedrake ID) failing unconditionally with `TypeError: SemiImplicitBDF.
+__init__() missing 1 required positional argument: 'dt'` -- the parent
+classes (TransientSolver, NavierStokesTransientSolver) both document and
+implement "dt defaults to flow.DEFAULT_DT if omitted", but SemiImplicitBDF
+required it positionally, breaking that inherited contract for every
+caller that didn't pass dt explicitly (this silently affected
+hydrogym/registration.py's Firedrake factories and at least two examples'
+own env_config dicts -- see the Verification Addendum for the full list).
+
+A signature check (not a full solve) is enough to pin this: SemiImplicitBDF
+never uses `dt` before forwarding it to `super().__init__(flow, dt, ...)`,
+which already resolves `None` correctly, so there's no solver-numerical
+behavior at stake here, only the constructor's default.
+"""
+
+import inspect
+
+import pytest
+
+pytest.importorskip("firedrake")
+
+from hydrogym.firedrake.solvers.bdf_ext import SemiImplicitBDF  # noqa: E402
+
+
+def test_dt_parameter_is_optional():
+    sig = inspect.signature(SemiImplicitBDF.__init__)
+    assert sig.parameters["dt"].default is None, (
+        "SemiImplicitBDF's dt must default to None (resolved to flow.DEFAULT_DT by "
+        "the parent TransientSolver/NavierStokesTransientSolver classes) -- making it "
+        "a required positional argument breaks every caller that omits dt, including "
+        "hydrogym.registration's gym.make() factories."
+    )


### PR DESCRIPTION
Tenth and final PR in the sequential \`hydrogym-audit-v2\` stack. Targets #291 (Examples verification pass).

## Scope

A follow-up question — "can every environment be started with a single,
mujoco/gymnasium-style \`gym.make(id, **kwargs)\`, with lower-level entry
points preserved?" — found that \`hydrogym.registration\` (Task 6.1)
existed for exactly this but had **never been exercised end-to-end
against real backends**: its only test file mocks the backend entirely,
so dispatch logic was tested but real construction never was, and it
didn't actually work. Calling it against live backends found and fixed
4 real bugs:

- \`SemiImplicitBDF\` required \`dt\` positionally, contradicting its own
  parent classes' "defaults to \`flow.DEFAULT_DT\`" contract — broke
  \`gym.make()\` for all 5 Firedrake IDs (same root cause as 2 of the
  Verification Addendum's "6 unrelated pre-existing failures", now fixed too)
- MAIA's factory imported \`hydrogym.maia.env_core\` directly, bypassing
  the package's lazy \`__getattr__\` loader — the only thing that ever
  populates the environment registry. Inside a real MPMD job this
  produced a 6+ minute hang, not a clean error (Python crashed while the
  paired MAIA rank waited forever for a handshake that would never come)
- MAIA's \`probe_locations\` had no default and no \`None\` check — added a
  clear \`ConfigError\` plus a verified default probe grid for
  \`Cylinder_2D_Re200\`
- \`hydrogym.jaxfluids.envs.__init__.py\` was empty (unlike every other
  backend's \`envs\` package) so \`Nozzle2D\`/\`Nozzle3D\` weren't reachable

Then declared \`gym.make()\` the standard entry point across every
README/doc, added \`test/test_registration_live.py\` (real, non-mocked
tests — the actual regression coverage this feature needed), regenerated
the API docs (which had drifted, including a docstring that broke the
Docusaurus MDX build once regenerated), and closed out two more
Finding-C-related checkpoint-ambiguity residuals plus a genuinely new bug
(\`linearize_dynamics\` passing an un-split \`Function\` to
\`NewtonSolver.steady_form\`) found while re-running the full Firedrake
suite one more time.

## Verified

- \`ruff check .\`, \`ruff format --check .\`, \`isort . --check-only --diff\`,
  codespell, \`uv lock --check\` all clean
- \`python test/measure_docstrings.py --fail-under 99\`: 454/454 (100%)
- \`import hydrogym.registration\` verified live: all 11 registered IDs
  present (\`hydrogym/{Cylinder,RotaryCylinder,Cavity,Pinball,Step}-v0\`,
  \`hydrogym-maia/*\`, \`hydrogym-nek/TCFmini_3D_Re180-v0\`,
  \`hydrogym-jaxfluids/{Nozzle2D,Nozzle3D}-v0\`)
- Every fix verified live against the real backends (Firedrake in-process,
  MAIA and Nek5000 as real MPMD jobs) — see \`HYDROGYM_ENGINEERING_AUDIT_v2.md\`

This closes out the full \`hydrogym-audit-v2\` engineering audit as a
sequential PR stack. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)